### PR TITLE
Rebuild as recursive task board with sub-board drill-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# SQLite database
+taskboard.db
+taskboard.db-shm
+taskboard.db-wal

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,12 @@
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
+        "better-sqlite3": "^12.10.0",
+        "concurrently": "^9.2.1",
+        "cors": "^2.8.6",
+        "express": "^5.2.1",
         "graphql": "^16.3.0",
+        "node-cron": "^4.2.1",
         "react": "^17.0.2",
         "react-beautiful-dnd": "^13.1.0",
         "react-dom": "^17.0.2",
@@ -3906,12 +3911,13 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
     "node_modules/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
@@ -4637,10 +4643,44 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -4672,62 +4712,79 @@
         "node": ">=8"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.1",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
-        "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.6",
-        "raw-body": "2.4.2",
-        "type-is": "~1.6.18"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/bonjour": {
       "version": "3.5.0",
@@ -4802,6 +4859,30 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4838,6 +4919,35 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4969,6 +5079,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
@@ -5158,6 +5274,156 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/concurrently/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -5172,39 +5438,23 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/content-disposition/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5218,17 +5468,22 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-js": {
       "version": "3.20.3",
@@ -5275,6 +5530,23 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -5745,11 +6017,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5773,6 +6046,21 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -5792,6 +6080,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -5880,9 +6177,23 @@
       }
     },
     "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -6109,6 +6420,20 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6117,7 +6442,8 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.6",
@@ -6163,11 +6489,21 @@
       }
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -6239,10 +6575,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -6988,7 +7354,8 @@
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7036,6 +7403,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.6.tgz",
@@ -7051,81 +7427,112 @@
       }
     },
     "node_modules/express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.7",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.19.1",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.4.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
+    "node_modules/express/node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "node_modules/express/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+    "node_modules/express/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -7225,6 +7632,12 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -7253,34 +7666,34 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
@@ -7539,12 +7952,19 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.0.0",
@@ -7583,9 +8003,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -7609,13 +8033,24 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7632,6 +8067,19 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -7659,6 +8107,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -7757,6 +8211,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -7822,9 +8288,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7844,6 +8311,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -7995,18 +8474,41 @@
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/http-parser-js": {
@@ -8115,6 +8617,26 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -8454,6 +8976,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -10723,17 +11251,27 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/memfs": {
@@ -10753,9 +11291,16 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -10773,7 +11318,8 @@
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10794,6 +11340,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -10826,6 +11373,18 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -10935,10 +11494,17 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
@@ -10968,15 +11534,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node_modules/negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10993,6 +11566,27 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -11084,9 +11678,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11210,9 +11808,10 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -11433,9 +12032,14 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -12623,6 +13227,33 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12740,6 +13371,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -12758,9 +13399,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -12828,34 +13473,65 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/raw-body/node_modules/bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13559,6 +14235,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13579,6 +14280,15 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -13702,45 +14412,64 @@
       }
     },
     "node_modules/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "1.8.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -13805,23 +14534,29 @@
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "node_modules/serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -13843,18 +14578,84 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13864,6 +14665,51 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -14494,6 +15340,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -14689,6 +15563,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -14723,6 +15598,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/tryer": {
@@ -14784,6 +15668,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -14815,15 +15711,59 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -14919,7 +15859,8 @@
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -14981,7 +15922,8 @@
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -15292,10 +16234,235 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/webpack-dev-server/node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/webpack-dev-server/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/webpack-dev-server/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/webpack-dev-server/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/webpack-dev-server/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/webpack-dev-server/node_modules/schema-utils": {
       "version": "4.0.0",
@@ -15315,6 +16482,54 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/strip-ansi": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
@@ -15327,6 +16542,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
@@ -18723,12 +19951,12 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
     "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       }
     },
     "acorn": {
@@ -19258,10 +20486,24 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+    },
+    "better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
     },
     "bfj": {
       "version": "7.0.2",
@@ -19284,53 +20526,57 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "requires": {
-        "bytes": "3.1.1",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
-        "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.6",
-        "raw-body": "2.4.2",
-        "type-is": "~1.6.18"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "dependencies": {
         "bytes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
         },
         "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+          "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -19394,6 +20640,15 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -19421,6 +20676,24 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "callsites": {
@@ -19512,6 +20785,11 @@
           }
         }
       }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -19671,6 +20949,103 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "requires": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+        }
+      }
+    },
     "confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -19682,24 +21057,14 @@
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
     "content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "requires": {
-        "safe-buffer": "5.2.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -19710,14 +21075,14 @@
       }
     },
     "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
     },
     "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
     },
     "core-js": {
       "version": "3.20.3",
@@ -19749,6 +21114,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -20077,11 +21451,11 @@
       }
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decimal.js": {
@@ -20093,6 +21467,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
     },
     "dedent": {
       "version": "0.7.0",
@@ -20111,6 +21493,11 @@
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -20174,9 +21561,14 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -20355,6 +21747,16 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -20363,7 +21765,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "ejs": {
       "version": "3.1.6",
@@ -20394,9 +21796,17 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+    },
+    "end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enhanced-resolve": {
       "version": "5.8.3",
@@ -20455,10 +21865,28 @@
         "unbox-primitive": "^1.0.1"
       }
     },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
     "es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -20988,7 +22416,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -21021,6 +22449,11 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "expect": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.6.tgz",
@@ -21033,64 +22466,76 @@
       }
     },
     "express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "requires": {
-        "accepts": "~1.3.7",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.19.1",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.4.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "dependencies": {
-        "array-flatten": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "accepts": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+          "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
           "requires": {
-            "ms": "2.0.0"
+            "mime-types": "^3.0.0",
+            "negotiator": "^1.0.0"
           }
         },
-        "ms": {
+        "depd": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+        },
+        "mime-types": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+          "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+          "requires": {
+            "mime-db": "^1.54.0"
+          }
+        },
+        "negotiator": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+          "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+        },
+        "statuses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+          "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
         }
       }
     },
@@ -21172,6 +22617,11 @@
         "schema-utils": "^3.0.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "filelist": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -21194,31 +22644,22 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        "statuses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+          "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
         }
       }
     },
@@ -21384,9 +22825,14 @@
       "integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA=="
     },
     "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "10.0.0",
@@ -21415,9 +22861,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -21435,13 +22881,20 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       }
     },
     "get-own-enumerable-property-symbols": {
@@ -21453,6 +22906,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -21467,6 +22929,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.2.0",
@@ -21540,6 +23007,11 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
     "graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -21587,9 +23059,9 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -21597,6 +23069,14 @@
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "he": {
@@ -21720,15 +23200,27 @@
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "statuses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+          "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+        }
       }
     },
     "http-parser-js": {
@@ -21808,6 +23300,11 @@
       "requires": {
         "harmony-reflect": "^1.4.6"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -22028,6 +23525,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -23683,15 +25185,20 @@
         "tmpl": "1.0.5"
       }
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
     },
     "memfs": {
       "version": "3.4.1",
@@ -23707,9 +25214,9 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -23724,7 +25231,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
     },
     "micromatch": {
       "version": "4.0.4",
@@ -23757,6 +25264,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
     },
     "min-indent": {
       "version": "1.0.1",
@@ -23834,10 +25346,15 @@
         "minimist": "^1.2.5"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -23858,15 +25375,20 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
       "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
     },
+    "napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -23881,6 +25403,19 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "requires": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg=="
     },
     "node-forge": {
       "version": "1.2.1",
@@ -23944,9 +25479,9 @@
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -24028,9 +25563,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -24185,9 +25720,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -24931,6 +26466,25 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -25027,6 +26581,15 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
+    "pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -25038,9 +26601,12 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "requires": {
+        "side-channel": "^1.1.0"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -25079,28 +26645,46 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "requires": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "bytes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
         },
         "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+          "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
         }
       }
     },
@@ -25609,12 +27193,39 @@
         }
       }
     },
+    "router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "requires": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "requires": {
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
@@ -25695,44 +27306,40 @@
       }
     },
     "send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "requires": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "1.8.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+        },
+        "mime-types": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+          "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
           "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
+            "mime-db": "^1.54.0"
           }
         },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        "statuses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+          "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
         }
       }
     },
@@ -25795,14 +27402,14 @@
       }
     },
     "serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       }
     },
     "setprototypeof": {
@@ -25824,24 +27431,73 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="
     },
     "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       }
     },
     "signal-exit": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -26318,6 +27974,29 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
+    "tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -26474,6 +28153,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
+    },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -26525,6 +28209,14 @@
         }
       }
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -26544,12 +28236,33 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "dependencies": {
+        "content-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+          "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+        },
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+        },
+        "mime-types": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+          "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+          "requires": {
+            "mime-db": "^1.54.0"
+          }
+        }
       }
     },
     "typedarray-to-buffer": {
@@ -26617,7 +28330,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "unquote": {
       "version": "1.1.1",
@@ -26667,7 +28380,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
       "version": "8.3.2",
@@ -26908,10 +28621,168 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
           "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
         },
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+        },
+        "body-parser": {
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+          "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+          "requires": {
+            "bytes": "~3.1.2",
+            "content-type": "~1.0.5",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "~1.2.0",
+            "http-errors": "~2.0.1",
+            "iconv-lite": "~0.4.24",
+            "on-finished": "~2.4.1",
+            "qs": "~6.15.1",
+            "raw-body": "~2.5.3",
+            "type-is": "~1.6.18",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "bytes": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+        },
+        "content-disposition": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+          "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+          "requires": {
+            "safe-buffer": "5.2.1"
+          }
+        },
+        "cookie-signature": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+          "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            }
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "express": {
+          "version": "4.22.2",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+          "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+          "requires": {
+            "accepts": "~1.3.8",
+            "array-flatten": "1.1.1",
+            "body-parser": "~1.20.5",
+            "content-disposition": "~0.5.4",
+            "content-type": "~1.0.4",
+            "cookie": "~0.7.1",
+            "cookie-signature": "~1.0.6",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "encodeurl": "~2.0.0",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "~1.3.1",
+            "fresh": "~0.5.2",
+            "http-errors": "~2.0.0",
+            "merge-descriptors": "1.0.3",
+            "methods": "~1.1.2",
+            "on-finished": "~2.4.1",
+            "parseurl": "~1.3.3",
+            "path-to-regexp": "~0.1.12",
+            "proxy-addr": "~2.0.7",
+            "qs": "~6.15.1",
+            "range-parser": "~1.2.1",
+            "safe-buffer": "5.2.1",
+            "send": "~0.19.0",
+            "serve-static": "~1.16.2",
+            "setprototypeof": "1.2.0",
+            "statuses": "~2.0.1",
+            "type-is": "~1.6.18",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          }
+        },
+        "finalhandler": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+          "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~2.0.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.4.1",
+            "parseurl": "~1.3.3",
+            "statuses": "~2.0.2",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+        },
+        "merge-descriptors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+          "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
+        },
+        "path-to-regexp": {
+          "version": "0.1.13",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+          "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
+        },
+        "raw-body": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+          "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+          "requires": {
+            "bytes": "~3.1.2",
+            "http-errors": "~2.0.1",
+            "iconv-lite": "~0.4.24",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "schema-utils": {
           "version": "4.0.0",
@@ -26924,12 +28795,57 @@
             "ajv-keywords": "^5.0.0"
           }
         },
+        "send": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+          "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "encodeurl": "~2.0.0",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "~0.5.2",
+            "http-errors": "~2.0.1",
+            "mime": "1.6.0",
+            "ms": "2.1.3",
+            "on-finished": "~2.4.1",
+            "range-parser": "~1.2.1",
+            "statuses": "~2.0.2"
+          }
+        },
+        "serve-static": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+          "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+          "requires": {
+            "encodeurl": "~2.0.0",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.3",
+            "send": "~0.19.1"
+          }
+        },
+        "statuses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+          "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+        },
         "strip-ansi": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
           "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
           "requires": {
             "ansi-regex": "^6.0.1"
+          }
+        },
+        "type-is": {
+          "version": "1.6.18",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+          "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.24"
           }
         },
         "ws": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,17 @@
   "name": "taskboard",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:3001",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
+    "better-sqlite3": "^12.10.0",
+    "concurrently": "^9.2.1",
+    "cors": "^2.8.6",
+    "express": "^5.2.1",
     "graphql": "^16.3.0",
+    "node-cron": "^4.2.1",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.1.0",
     "react-dom": "^17.0.2",
@@ -15,7 +21,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "concurrently -n server,react -c cyan,magenta \"node server/index.js\" \"react-scripts start\"",
+    "server": "node server/index.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>TaskBoard</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/server/automation/executor.js
+++ b/server/automation/executor.js
@@ -1,0 +1,139 @@
+// Type-specific automation execution logic
+
+const http  = require('http')
+const https = require('https')
+const net   = require('net')
+const { exec } = require('child_process')
+const log = require('../logger')
+
+// ── HTTP Check ──────────────────────────────────────────────────────────────
+
+function httpCheck(config) {
+  const { url, method = 'GET', expectedStatus = 200, timeout = 5000, expectedContent } = config
+  const start = Date.now()
+
+  return new Promise((resolve) => {
+    let urlObj
+    try { urlObj = new URL(url) } catch {
+      return resolve({ success: false, error: `Invalid URL: ${url}`, duration: 0 })
+    }
+
+    const client = urlObj.protocol === 'https:' ? https : http
+    const req = client.request(
+      { hostname: urlObj.hostname, port: urlObj.port || undefined,
+        path: urlObj.pathname + urlObj.search, method },
+      (res) => {
+        let body = ''
+        res.on('data', (chunk) => { body += chunk })
+        res.on('end', () => {
+          const duration = Date.now() - start
+          const statusOk = res.statusCode === expectedStatus
+          const contentOk = expectedContent ? body.includes(expectedContent) : true
+          resolve({
+            success: statusOk && contentOk,
+            statusCode: res.statusCode,
+            expectedStatus,
+            contentMatch: contentOk,
+            duration,
+          })
+        })
+      }
+    )
+
+    req.setTimeout(timeout, () => {
+      req.destroy()
+      resolve({ success: false, error: 'timeout', duration: timeout })
+    })
+    req.on('error', (e) => {
+      resolve({ success: false, error: e.message, duration: Date.now() - start })
+    })
+    req.end()
+  })
+}
+
+// ── Process / Port Check ────────────────────────────────────────────────────
+
+function portCheck(host, port, timeout = 3000) {
+  return new Promise((resolve) => {
+    const sock = new net.Socket()
+    const timer = setTimeout(() => {
+      sock.destroy()
+      resolve({ open: false, error: 'timeout' })
+    }, timeout)
+
+    sock.connect(port, host, () => {
+      clearTimeout(timer)
+      sock.destroy()
+      resolve({ open: true })
+    })
+    sock.on('error', (e) => {
+      clearTimeout(timer)
+      resolve({ open: false, error: e.message })
+    })
+  })
+}
+
+function processNameCheck(name) {
+  return new Promise((resolve) => {
+    exec(`pgrep -f "${name}"`, { timeout: 3000 }, (err, stdout) => {
+      const pids = stdout ? stdout.trim().split('\n').filter(Boolean) : []
+      resolve({ running: pids.length > 0, pids })
+    })
+  })
+}
+
+async function processCheck(config) {
+  const start = Date.now()
+  if (config.checkType === 'port') {
+    const result = await portCheck(config.host || 'localhost', config.port)
+    return { success: result.open, ...result, duration: Date.now() - start }
+  }
+  if (config.checkType === 'process') {
+    const result = await processNameCheck(config.processName)
+    return { success: result.running, ...result, duration: Date.now() - start }
+  }
+  return { success: false, error: 'Unknown checkType', duration: 0 }
+}
+
+// ── Cron Command ────────────────────────────────────────────────────────────
+
+function cronExec(config) {
+  const { command, timeout = 30000 } = config
+  const start = Date.now()
+
+  return new Promise((resolve) => {
+    exec(command, { timeout }, (error, stdout, stderr) => {
+      resolve({
+        success: !error,
+        exitCode: error ? (error.code || 1) : 0,
+        stdout: (stdout || '').trim().slice(0, 2000),
+        stderr: (stderr || '').trim().slice(0, 500),
+        duration: Date.now() - start,
+        error: error ? error.message : null,
+      })
+    })
+  })
+}
+
+// ── Dispatch ─────────────────────────────────────────────────────────────────
+
+async function execute(automation) {
+  const config = typeof automation.config === 'string'
+    ? JSON.parse(automation.config)
+    : automation.config
+
+  log.debug(`Executing automation [${automation.id}] type=${automation.type}`)
+
+  switch (automation.type) {
+    case 'http_check':    return httpCheck(config)
+    case 'process_check': return processCheck(config)
+    case 'cron':          return cronExec(config)
+    case 'webhook':
+      // Webhooks are event-driven; "execute" is a no-op poll
+      return { success: true, note: 'webhook — waiting for incoming push' }
+    default:
+      return { success: false, error: `Unknown type: ${automation.type}` }
+  }
+}
+
+module.exports = { execute }

--- a/server/automation/runner.js
+++ b/server/automation/runner.js
@@ -1,0 +1,102 @@
+// Automation scheduler — loads automations from DB, schedules via node-cron,
+// persists results, and broadcasts SSE updates.
+
+const cron = require('node-cron')
+const { randomUUID } = require('crypto')
+const db = require('../db')
+const { execute } = require('./executor')
+const { broadcast } = require('../sse')
+const log = require('../logger')
+
+const jobs = new Map()   // automationId → cron.Task
+
+// ── Run one automation ───────────────────────────────────────────────────────
+
+async function runAutomation(automationId) {
+  const auto = db.prepare('SELECT * FROM automations WHERE id = ?').get(automationId)
+  if (!auto || !auto.enabled) return
+
+  log.debug(`Running automation ${automationId} (${auto.name})`)
+
+  db.prepare(`UPDATE automations SET status = 'running', updated_at = datetime('now') WHERE id = ?`)
+    .run(automationId)
+  broadcast('automation-update', { automationId, status: 'running' })
+
+  let result, status
+  try {
+    result = await execute(auto)
+    status = result.success ? 'success' : 'failure'
+  } catch (err) {
+    result = { error: err.message }
+    status = 'error'
+    log.error(`Automation ${automationId} threw:`, err.message)
+  }
+
+  const now = new Date().toISOString()
+  const resultJson = JSON.stringify(result)
+
+  db.prepare(`
+    UPDATE automations
+    SET status = ?, last_run = ?, last_result = ?, updated_at = datetime('now')
+    WHERE id = ?
+  `).run(status, now, resultJson, automationId)
+
+  db.prepare(`
+    INSERT INTO automation_logs (id, automation_id, status, result, error, duration_ms)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(
+    randomUUID(),
+    automationId,
+    status,
+    resultJson,
+    result.error || null,
+    result.duration || null
+  )
+
+  log.info(`Automation [${auto.name}] → ${status}`)
+  broadcast('automation-update', { automationId, status, result, lastRun: now })
+}
+
+// ── Schedule management ──────────────────────────────────────────────────────
+
+function scheduleAutomation(auto) {
+  if (jobs.has(auto.id)) {
+    jobs.get(auto.id).stop()
+    jobs.delete(auto.id)
+  }
+
+  if (!auto.enabled) return
+
+  if (!cron.validate(auto.schedule)) {
+    log.warn(`Invalid cron expression for automation ${auto.id}: "${auto.schedule}"`)
+    return
+  }
+
+  const task = cron.schedule(auto.schedule, () => runAutomation(auto.id), { scheduled: true })
+  jobs.set(auto.id, task)
+  log.info(`Scheduled automation [${auto.name}] on "${auto.schedule}"`)
+}
+
+function unscheduleAutomation(automationId) {
+  if (jobs.has(automationId)) {
+    jobs.get(automationId).stop()
+    jobs.delete(automationId)
+    log.info(`Unscheduled automation ${automationId}`)
+  }
+}
+
+// ── Startup ──────────────────────────────────────────────────────────────────
+
+function startAll() {
+  const automations = db.prepare('SELECT * FROM automations WHERE enabled = 1').all()
+  log.info(`Starting ${automations.length} automation(s)`)
+  automations.forEach(scheduleAutomation)
+}
+
+// ── Manual trigger ────────────────────────────────────────────────────────────
+
+async function triggerNow(automationId) {
+  return runAutomation(automationId)
+}
+
+module.exports = { startAll, scheduleAutomation, unscheduleAutomation, triggerNow }

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,155 @@
+const Database = require('better-sqlite3')
+const path = require('path')
+const { randomUUID } = require('crypto')
+const log = require('./logger')
+
+const DB_PATH = path.join(__dirname, '..', 'taskboard.db')
+const db = new Database(DB_PATH)
+
+db.pragma('journal_mode = WAL')
+db.pragma('foreign_keys = ON')
+
+// ── Schema ─────────────────────────────────────────────────────────────────
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS boards (
+    id              TEXT PRIMARY KEY,
+    title           TEXT NOT NULL,
+    parent_task_id  TEXT,
+    created_at      TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS columns (
+    id              TEXT PRIMARY KEY,
+    board_id        TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+    title           TEXT NOT NULL,
+    subtitle        TEXT,
+    position        INTEGER NOT NULL DEFAULT 0,
+    color_key       TEXT,
+    is_automation   INTEGER NOT NULL DEFAULT 0,
+    allow_new_tasks INTEGER NOT NULL DEFAULT 1,
+    created_at      TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS tasks (
+    id              TEXT PRIMARY KEY,
+    board_id        TEXT NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+    column_id       TEXT NOT NULL REFERENCES columns(id) ON DELETE CASCADE,
+    title           TEXT NOT NULL,
+    description     TEXT,
+    due_date        TEXT,
+    repeat_pattern  TEXT,
+    position        INTEGER NOT NULL DEFAULT 0,
+    sub_board_id    TEXT,
+    created_at      TEXT DEFAULT (datetime('now')),
+    updated_at      TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS automations (
+    id          TEXT PRIMARY KEY,
+    task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    type        TEXT NOT NULL CHECK(type IN ('http_check','process_check','cron','webhook')),
+    config      TEXT NOT NULL DEFAULT '{}',
+    enabled     INTEGER NOT NULL DEFAULT 1,
+    status      TEXT NOT NULL DEFAULT 'pending'
+                  CHECK(status IN ('pending','running','success','failure','error')),
+    last_run    TEXT,
+    last_result TEXT,
+    schedule    TEXT NOT NULL DEFAULT '*/5 * * * *',
+    created_at  TEXT DEFAULT (datetime('now')),
+    updated_at  TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS automation_logs (
+    id             TEXT PRIMARY KEY,
+    automation_id  TEXT NOT NULL REFERENCES automations(id) ON DELETE CASCADE,
+    status         TEXT NOT NULL CHECK(status IN ('success','failure','timeout','error')),
+    result         TEXT,
+    error          TEXT,
+    duration_ms    INTEGER,
+    run_at         TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_tasks_board     ON tasks(board_id);
+  CREATE INDEX IF NOT EXISTS idx_tasks_column    ON tasks(column_id);
+  CREATE INDEX IF NOT EXISTS idx_columns_board   ON columns(board_id);
+  CREATE INDEX IF NOT EXISTS idx_logs_automation ON automation_logs(automation_id);
+`)
+
+// ── Seed ───────────────────────────────────────────────────────────────────
+
+function seed() {
+  if (db.prepare('SELECT 1 FROM boards WHERE id = ?').get('root')) return
+
+  log.info('Seeding initial data')
+
+  const insertBoard = db.prepare('INSERT INTO boards (id, title, parent_task_id) VALUES (?, ?, ?)')
+  const insertCol   = db.prepare(`
+    INSERT INTO columns (id, board_id, title, subtitle, position, color_key, is_automation, allow_new_tasks)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertTask  = db.prepare(`
+    INSERT INTO tasks (id, board_id, column_id, title, description, due_date, repeat_pattern, position, sub_board_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertAuto  = db.prepare(`
+    INSERT INTO automations (id, task_id, name, type, config, enabled, status, schedule)
+    VALUES (?, ?, ?, ?, ?, 1, 'pending', ?)
+  `)
+
+  db.transaction(() => {
+    // ── Root board & columns ──────────────────────────────────────────────
+    insertBoard.run('root', 'Root Board', null)
+
+    insertCol.run('col_automations', 'root', 'Automations', null,            0, 'automations', 1, 0)
+    insertCol.run('col_todo',        'root', 'To Do',       null,            1, null,           0, 1)
+    insertCol.run('col_late',        'root', 'Late',        null,            2, 'late',         0, 0)
+    insertCol.run('col_onHold',      'root', 'Not My Problem', '(right now)',3, 'onHold',       0, 0)
+    insertCol.run('col_inProgress',  'root', 'In Progress', null,            4, 'inProgress',   0, 0)
+    insertCol.run('col_completed',   'root', 'Completed',   null,            5, 'completed',    0, 0)
+
+    // ── Root tasks (sub_board_id null for now — set after boards exist) ───
+    insertTask.run('task_1', 'root', 'col_automations', 'Trash',                   null,                                               '22:00',      'Tuesday',  0, null)
+    insertTask.run('task_7', 'root', 'col_automations', 'Laundry',                 null,                                               '12:00',      'Saturday', 1, null)
+    insertTask.run('task_2', 'root', 'col_todo',        'Design portfolio website', 'Overall layout and structure',                     '2022-02-01', null,       0, null)
+    insertTask.run('task_8', 'root', 'col_todo',        'Make this persistent',    null,                                                '2022-02-10', null,       1, null)
+    insertTask.run('task_9', 'root', 'col_todo',        'Add sub-boards to tasks', null,                                                '2022-02-10', null,       2, null)
+    insertTask.run('task_3', 'root', 'col_late',        'Finish Bookshelf',        null,                                                '2022-02-14', null,       0, null)
+    insertTask.run('task_6', 'root', 'col_onHold',      'Figure out Wipro W2',     'Low confidence they will send one. Escalate on due date.', '2022-03-01', null, 0, null)
+    insertTask.run('task_4', 'root', 'col_completed',   'Buy Stain',               'Dark coffee color',                                 '2022-02-02', null,       0, null)
+
+    // ── Sub-board for "Finish Bookshelf" ─────────────────────────────────
+    insertBoard.run('board_task_3', 'Finish Bookshelf', 'task_3')
+
+    insertCol.run('board_task_3_todo',       'board_task_3', 'To Do',       null, 0, null,        0, 1)
+    insertCol.run('board_task_3_inProgress', 'board_task_3', 'In Progress', null, 1, 'inProgress', 0, 0)
+    insertCol.run('board_task_3_done',       'board_task_3', 'Done',        null, 2, 'completed',  0, 0)
+
+    insertTask.run('task_5', 'board_task_3', 'board_task_3_todo',
+      'Apply Stain', "Assemble first — check for cold-warped boards", '2022-02-02', null, 0, null)
+
+    // Now link task_3 → its sub-board
+    db.prepare("UPDATE tasks SET sub_board_id = 'board_task_3' WHERE id = 'task_3'").run()
+
+    // ── Sample automations ────────────────────────────────────────────────
+    insertAuto.run(
+      randomUUID(), 'task_1', 'Health endpoint check',
+      'http_check',
+      JSON.stringify({ url: 'http://localhost:3001/api/health', expectedStatus: 200, timeout: 4000 }),
+      '*/2 * * * *'
+    )
+    insertAuto.run(
+      randomUUID(), 'task_7', 'Local port monitor',
+      'process_check',
+      JSON.stringify({ checkType: 'port', host: 'localhost', port: 3001 }),
+      '*/1 * * * *'
+    )
+  })()
+
+  log.info('Seed complete')
+}
+
+seed()
+
+module.exports = db

--- a/server/db.js
+++ b/server/db.js
@@ -71,10 +71,44 @@ db.exec(`
     run_at         TEXT DEFAULT (datetime('now'))
   );
 
-  CREATE INDEX IF NOT EXISTS idx_tasks_board     ON tasks(board_id);
-  CREATE INDEX IF NOT EXISTS idx_tasks_column    ON tasks(column_id);
-  CREATE INDEX IF NOT EXISTS idx_columns_board   ON columns(board_id);
-  CREATE INDEX IF NOT EXISTS idx_logs_automation ON automation_logs(automation_id);
+  CREATE TABLE IF NOT EXISTS requirements (
+    id          TEXT PRIMARY KEY,
+    task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    text        TEXT NOT NULL,
+    priority    TEXT NOT NULL DEFAULT 'medium'
+                  CHECK(priority IN ('high','medium','low')),
+    source      TEXT,
+    position    INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS verifications (
+    id           TEXT PRIMARY KEY,
+    task_id      TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    text         TEXT NOT NULL,
+    type         TEXT NOT NULL DEFAULT 'manual'
+                   CHECK(type IN ('manual','automated','inspection','demonstration')),
+    status       TEXT NOT NULL DEFAULT 'pending'
+                   CHECK(status IN ('pending','in_progress','passed','failed')),
+    result_notes TEXT,
+    verified_at  TEXT,
+    position     INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT DEFAULT (datetime('now'))
+  );
+
+  -- Many-to-many: each requirement can map to many verifications and vice-versa
+  CREATE TABLE IF NOT EXISTS req_ver_links (
+    requirement_id  TEXT NOT NULL REFERENCES requirements(id) ON DELETE CASCADE,
+    verification_id TEXT NOT NULL REFERENCES verifications(id) ON DELETE CASCADE,
+    PRIMARY KEY (requirement_id, verification_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_tasks_board        ON tasks(board_id);
+  CREATE INDEX IF NOT EXISTS idx_tasks_column       ON tasks(column_id);
+  CREATE INDEX IF NOT EXISTS idx_columns_board      ON columns(board_id);
+  CREATE INDEX IF NOT EXISTS idx_logs_automation    ON automation_logs(automation_id);
+  CREATE INDEX IF NOT EXISTS idx_reqs_task          ON requirements(task_id);
+  CREATE INDEX IF NOT EXISTS idx_vers_task          ON verifications(task_id);
 `)
 
 // ── Seed ───────────────────────────────────────────────────────────────────
@@ -145,6 +179,35 @@ function seed() {
       JSON.stringify({ checkType: 'port', host: 'localhost', port: 3001 }),
       '*/1 * * * *'
     )
+
+    // ── V-diagram demo on "Finish Bookshelf" (task_3) ───────────────────
+    const insertReq = db.prepare(`
+      INSERT INTO requirements (id, task_id, text, priority, source, position)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `)
+    const insertVer = db.prepare(`
+      INSERT INTO verifications (id, task_id, text, type, status, position)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `)
+    const insertLink = db.prepare(
+      'INSERT INTO req_ver_links (requirement_id, verification_id) VALUES (?, ?)'
+    )
+
+    const r1 = randomUUID(), r2 = randomUUID(), r3 = randomUUID()
+    const v1 = randomUUID(), v2 = randomUUID(), v3 = randomUUID()
+
+    insertReq.run(r1, 'task_3', 'All boards must be smooth and splinter-free',      'high',   'Product spec', 0)
+    insertReq.run(r2, 'task_3', 'Stain color matches dark coffee reference swatch', 'high',   'Product spec', 1)
+    insertReq.run(r3, 'task_3', 'All joints flush and structurally sound',          'medium', 'Safety',       2)
+
+    insertVer.run(v1, 'task_3', 'Visual and tactile inspection of all surfaces', 'inspection',    'pending', 0)
+    insertVer.run(v2, 'task_3', 'Color swatch comparison under natural light',   'manual',        'pending', 1)
+    insertVer.run(v3, 'task_3', 'Load test with 30 kg weight for 24 h',          'demonstration', 'pending', 2)
+
+    insertLink.run(r1, v1)
+    insertLink.run(r2, v2)
+    insertLink.run(r3, v1)
+    insertLink.run(r3, v3)
   })()
 
   log.info('Seed complete')

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,42 @@
+const express = require('express')
+const cors    = require('cors')
+const path    = require('path')
+const log     = require('./logger')
+
+const boardRoutes      = require('./routes/boards')
+const automationRoutes = require('./routes/automations')
+const { startAll }     = require('./automation/runner')
+
+const app  = express()
+const PORT = process.env.PORT || 3001
+
+app.use(cors({ origin: 'http://localhost:3000' }))
+app.use(express.json())
+
+// ── Health ────────────────────────────────────────────────────────────────────
+app.get('/api/health', (req, res) => res.json({ ok: true, ts: new Date().toISOString() }))
+
+// ── API routes ────────────────────────────────────────────────────────────────
+app.use('/api/boards',      boardRoutes)
+app.use('/api/automations', automationRoutes)
+
+// Webhook receiver hangs off the automations router but needs its own path
+// (already registered inside automations.js as /webhooks/:id on the router,
+//  but we expose it at /webhooks/:id at the root level for external access)
+app.post('/webhooks/:id', (req, res, next) => {
+  req.url = `/webhooks/${req.params.id}`
+  automationRoutes(req, res, next)
+})
+
+// ── Serve production build ─────────────────────────────────────────────────────
+const buildDir = path.join(__dirname, '..', 'build')
+app.use(express.static(buildDir))
+app.use((req, res) => res.sendFile(path.join(buildDir, 'index.html')))
+
+// ── Start ─────────────────────────────────────────────────────────────────────
+app.listen(PORT, () => {
+  log.info(`Server listening on http://localhost:${PORT}`)
+  startAll()
+})
+
+module.exports = app

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const log     = require('./logger')
 
 const boardRoutes      = require('./routes/boards')
 const automationRoutes = require('./routes/automations')
+const vdiagramRoutes   = require('./routes/vdiagram')
 const { startAll }     = require('./automation/runner')
 
 const app  = express()
@@ -19,6 +20,7 @@ app.get('/api/health', (req, res) => res.json({ ok: true, ts: new Date().toISOSt
 // ── API routes ────────────────────────────────────────────────────────────────
 app.use('/api/boards',      boardRoutes)
 app.use('/api/automations', automationRoutes)
+app.use('/api',             vdiagramRoutes)
 
 // Webhook receiver hangs off the automations router but needs its own path
 // (already registered inside automations.js as /webhooks/:id on the router,

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,0 +1,12 @@
+const isDev = process.env.NODE_ENV !== 'production'
+
+const ts = () => new Date().toISOString().slice(11, 23)
+
+const logger = {
+  info:  (...a) => console.log( `[${ts()}] [INFO ]`, ...a),
+  warn:  (...a) => console.warn(`[${ts()}] [WARN ]`, ...a),
+  error: (...a) => console.error(`[${ts()}] [ERROR]`, ...a),
+  debug: (...a) => { if (isDev) console.log(`[${ts()}] [DEBUG]`, ...a) },
+}
+
+module.exports = logger

--- a/server/routes/automations.js
+++ b/server/routes/automations.js
@@ -1,0 +1,184 @@
+// Automation CRUD, SSE stream, webhook receiver, and manual trigger
+
+const { Router } = require('express')
+const { randomUUID } = require('crypto')
+const db  = require('../db')
+const sse = require('../sse')
+const log = require('../logger')
+
+const router = Router()
+
+// ── SSE stream ────────────────────────────────────────────────────────────────
+
+// GET /api/automations/stream — clients connect here for live status pushes
+router.get('/stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+  res.setHeader('X-Accel-Buffering', 'no')
+  res.flushHeaders()
+
+  // Send current snapshot on connect
+  const automations = db.prepare('SELECT id, status, last_run, last_result FROM automations').all()
+  res.write(`event: snapshot\ndata: ${JSON.stringify(automations)}\n\n`)
+
+  sse.addClient(res)
+  log.debug('SSE client connected')
+
+  req.on('close', () => {
+    sse.removeClient(res)
+    log.debug('SSE client disconnected')
+  })
+})
+
+// ── Automation CRUD ───────────────────────────────────────────────────────────
+
+// GET /api/automations — list all with task title
+router.get('/', (req, res) => {
+  const rows = db.prepare(`
+    SELECT a.*, t.title AS task_title
+    FROM automations a
+    JOIN tasks t ON t.id = a.task_id
+    ORDER BY a.created_at DESC
+  `).all()
+  res.json(rows)
+})
+
+// GET /api/automations/:id — detail + last 20 logs
+router.get('/:id', (req, res) => {
+  const auto = db.prepare(`
+    SELECT a.*, t.title AS task_title
+    FROM automations a
+    JOIN tasks t ON t.id = a.task_id
+    WHERE a.id = ?
+  `).get(req.params.id)
+  if (!auto) return res.status(404).json({ error: 'Not found' })
+
+  const logs = db.prepare(
+    'SELECT * FROM automation_logs WHERE automation_id = ? ORDER BY run_at DESC LIMIT 20'
+  ).all(req.params.id)
+
+  res.json({ ...auto, logs })
+})
+
+// POST /api/automations — create
+router.post('/', (req, res) => {
+  const { taskId, name, type, config, schedule, enabled = true } = req.body
+  if (!taskId || !name || !type || !config)
+    return res.status(400).json({ error: 'taskId, name, type, config required' })
+
+  const validTypes = ['http_check', 'process_check', 'cron', 'webhook']
+  if (!validTypes.includes(type))
+    return res.status(400).json({ error: `type must be one of: ${validTypes.join(', ')}` })
+
+  const id = randomUUID()
+  db.prepare(`
+    INSERT INTO automations (id, task_id, name, type, config, enabled, schedule)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(id, taskId, name, type, JSON.stringify(config), enabled ? 1 : 0, schedule || '*/5 * * * *')
+
+  // Dynamically schedule if enabled (runner is already started)
+  if (enabled) {
+    const { scheduleAutomation } = require('../automation/runner')
+    scheduleAutomation(db.prepare('SELECT * FROM automations WHERE id = ?').get(id))
+  }
+
+  log.info(`Created automation ${id} (${type}) for task ${taskId}`)
+  res.status(201).json(db.prepare('SELECT * FROM automations WHERE id = ?').get(id))
+})
+
+// PATCH /api/automations/:id — update
+router.patch('/:id', (req, res) => {
+  const auto = db.prepare('SELECT * FROM automations WHERE id = ?').get(req.params.id)
+  if (!auto) return res.status(404).json({ error: 'Not found' })
+
+  const { name, type, config, schedule, enabled } = req.body
+
+  db.prepare(`
+    UPDATE automations SET
+      name     = COALESCE(?, name),
+      type     = COALESCE(?, type),
+      config   = COALESCE(?, config),
+      schedule = COALESCE(?, schedule),
+      enabled  = COALESCE(?, enabled),
+      updated_at = datetime('now')
+    WHERE id = ?
+  `).run(
+    name || null,
+    type || null,
+    config ? JSON.stringify(config) : null,
+    schedule || null,
+    enabled !== undefined ? (enabled ? 1 : 0) : null,
+    req.params.id
+  )
+
+  const updated = db.prepare('SELECT * FROM automations WHERE id = ?').get(req.params.id)
+  const { scheduleAutomation, unscheduleAutomation } = require('../automation/runner')
+  updated.enabled ? scheduleAutomation(updated) : unscheduleAutomation(req.params.id)
+
+  log.info(`Updated automation ${req.params.id}`)
+  res.json(updated)
+})
+
+// DELETE /api/automations/:id
+router.delete('/:id', (req, res) => {
+  if (!db.prepare('SELECT 1 FROM automations WHERE id = ?').get(req.params.id))
+    return res.status(404).json({ error: 'Not found' })
+
+  const { unscheduleAutomation } = require('../automation/runner')
+  unscheduleAutomation(req.params.id)
+  db.prepare('DELETE FROM automations WHERE id = ?').run(req.params.id)
+  log.info(`Deleted automation ${req.params.id}`)
+  res.status(204).end()
+})
+
+// POST /api/automations/:id/trigger — manual run
+router.post('/:id/trigger', async (req, res) => {
+  if (!db.prepare('SELECT 1 FROM automations WHERE id = ?').get(req.params.id))
+    return res.status(404).json({ error: 'Not found' })
+
+  log.info(`Manual trigger: ${req.params.id}`)
+  const { triggerNow } = require('../automation/runner')
+  await triggerNow(req.params.id)
+  const updated = db.prepare('SELECT * FROM automations WHERE id = ?').get(req.params.id)
+  res.json(updated)
+})
+
+// GET /api/automations/:id/logs
+router.get('/:id/logs', (req, res) => {
+  const limit  = Math.min(parseInt(req.query.limit) || 50, 200)
+  const offset = parseInt(req.query.offset) || 0
+  const logs = db.prepare(
+    'SELECT * FROM automation_logs WHERE automation_id = ? ORDER BY run_at DESC LIMIT ? OFFSET ?'
+  ).all(req.params.id, limit, offset)
+  res.json(logs)
+})
+
+// ── Webhook receiver ──────────────────────────────────────────────────────────
+
+// POST /webhooks/:id — external systems push events here
+router.post('/webhooks/:id', (req, res) => {
+  const auto = db.prepare('SELECT * FROM automations WHERE id = ? AND type = ?')
+    .get(req.params.id, 'webhook')
+  if (!auto) return res.status(404).json({ error: 'Webhook automation not found' })
+
+  const now  = new Date().toISOString()
+  const payload = { receivedAt: now, body: req.body, headers: req.headers }
+  const resultJson = JSON.stringify(payload)
+
+  db.prepare(`
+    UPDATE automations SET status = 'success', last_run = ?, last_result = ?, updated_at = datetime('now')
+    WHERE id = ?
+  `).run(now, resultJson, auto.id)
+
+  db.prepare(`
+    INSERT INTO automation_logs (id, automation_id, status, result)
+    VALUES (?, ?, 'success', ?)
+  `).run(randomUUID(), auto.id, resultJson)
+
+  sse.broadcast('automation-update', { automationId: auto.id, status: 'success', result: payload, lastRun: now })
+  log.info(`Webhook received for automation ${auto.id}`)
+  res.json({ ok: true })
+})
+
+module.exports = router

--- a/server/routes/boards.js
+++ b/server/routes/boards.js
@@ -1,0 +1,207 @@
+// Board, column, and task CRUD routes
+
+const { Router } = require('express')
+const { randomUUID } = require('crypto')
+const db  = require('../db')
+const log = require('../logger')
+
+const router = Router()
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getFullBoard(boardId) {
+  const board = db.prepare('SELECT * FROM boards WHERE id = ?').get(boardId)
+  if (!board) return null
+
+  const columns = db.prepare(
+    'SELECT * FROM columns WHERE board_id = ? ORDER BY position'
+  ).all(boardId)
+
+  const tasksRaw = db.prepare(
+    'SELECT * FROM tasks WHERE board_id = ? ORDER BY position'
+  ).all(boardId)
+
+  // Attach automation status to each task (if any)
+  const autoByTask = {}
+  const autos = db.prepare(
+    `SELECT a.id, a.task_id, a.name, a.type, a.status, a.last_run, a.last_result, a.schedule, a.enabled
+     FROM automations a
+     WHERE a.task_id IN (SELECT id FROM tasks WHERE board_id = ?)`
+  ).all(boardId)
+  for (const a of autos) {
+    if (!autoByTask[a.task_id]) autoByTask[a.task_id] = []
+    autoByTask[a.task_id].push(a)
+  }
+
+  const tasksByCol = {}
+  for (const t of tasksRaw) {
+    if (!tasksByCol[t.column_id]) tasksByCol[t.column_id] = []
+    tasksByCol[t.column_id].push({ ...t, automations: autoByTask[t.id] || [] })
+  }
+
+  return {
+    id: board.id,
+    title: board.title,
+    parentTaskId: board.parent_task_id || null,
+    columns: columns.map(c => ({
+      id: c.id,
+      title: c.title,
+      subtitle: c.subtitle || null,
+      position: c.position,
+      colorKey: c.color_key,
+      isAutomation: !!c.is_automation,
+      allowNewTasks: !!c.allow_new_tasks,
+      tasks: tasksByCol[c.id] || [],
+    })),
+  }
+}
+
+// ── Board routes ─────────────────────────────────────────────────────────────
+
+// GET /api/boards/:id
+router.get('/:id', (req, res) => {
+  const board = getFullBoard(req.params.id)
+  if (!board) return res.status(404).json({ error: 'Board not found' })
+  log.debug(`GET board ${req.params.id} (${board.columns.length} cols)`)
+  res.json(board)
+})
+
+// POST /api/boards — create a standalone board
+router.post('/', (req, res) => {
+  const { title } = req.body
+  if (!title) return res.status(400).json({ error: 'title required' })
+  const id = randomUUID()
+  db.prepare('INSERT INTO boards (id, title) VALUES (?, ?)').run(id, title)
+  log.info(`Created board ${id}: ${title}`)
+  res.status(201).json({ id, title })
+})
+
+// ── Task routes ───────────────────────────────────────────────────────────────
+
+// POST /api/tasks — create a task
+router.post('/tasks', (req, res) => {
+  const { boardId, columnId, title, description, dueDate, repeatPattern } = req.body
+  if (!boardId || !columnId || !title)
+    return res.status(400).json({ error: 'boardId, columnId, title required' })
+
+  const maxPos = db.prepare(
+    'SELECT COALESCE(MAX(position), -1) as m FROM tasks WHERE column_id = ?'
+  ).get(columnId).m
+
+  const id = randomUUID()
+  db.prepare(`
+    INSERT INTO tasks (id, board_id, column_id, title, description, due_date, repeat_pattern, position)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, boardId, columnId, title, description || null, dueDate || null, repeatPattern || null, maxPos + 1)
+
+  log.info(`Created task ${id}: "${title}" in ${columnId}`)
+  res.status(201).json(db.prepare('SELECT * FROM tasks WHERE id = ?').get(id))
+})
+
+// PATCH /api/tasks/:id — update task fields
+router.patch('/tasks/:id', (req, res) => {
+  const { title, description, dueDate, repeatPattern } = req.body
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id)
+  if (!task) return res.status(404).json({ error: 'Task not found' })
+
+  db.prepare(`
+    UPDATE tasks SET
+      title          = COALESCE(?, title),
+      description    = ?,
+      due_date       = ?,
+      repeat_pattern = ?,
+      updated_at     = datetime('now')
+    WHERE id = ?
+  `).run(
+    title || null,
+    description !== undefined ? description : task.description,
+    dueDate !== undefined ? dueDate : task.due_date,
+    repeatPattern !== undefined ? repeatPattern : task.repeat_pattern,
+    req.params.id
+  )
+  log.info(`Updated task ${req.params.id}`)
+  res.json(db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id))
+})
+
+// DELETE /api/tasks/:id
+router.delete('/tasks/:id', (req, res) => {
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id)
+  if (!task) return res.status(404).json({ error: 'Task not found' })
+  db.prepare('DELETE FROM tasks WHERE id = ?').run(req.params.id)
+  log.info(`Deleted task ${req.params.id}`)
+  res.status(204).end()
+})
+
+// POST /api/tasks/:id/move — drag-and-drop reorder
+router.post('/tasks/:id/move', (req, res) => {
+  const { targetColumnId, targetPosition } = req.body
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id)
+  if (!task) return res.status(404).json({ error: 'Task not found' })
+
+  const srcColId = task.column_id
+  const dstColId = targetColumnId
+
+  db.transaction(() => {
+    if (srcColId === dstColId) {
+      // Reorder within same column
+      const tasks = db.prepare(
+        'SELECT id FROM tasks WHERE column_id = ? ORDER BY position'
+      ).all(srcColId).map(t => t.id)
+      tasks.splice(tasks.indexOf(req.params.id), 1)
+      tasks.splice(targetPosition, 0, req.params.id)
+      const upd = db.prepare('UPDATE tasks SET position = ? WHERE id = ?')
+      tasks.forEach((id, i) => upd.run(i, id))
+    } else {
+      // Move to different column: remove from source, insert at dest
+      const srcTasks = db.prepare(
+        'SELECT id FROM tasks WHERE column_id = ? ORDER BY position'
+      ).all(srcColId).map(t => t.id).filter(id => id !== req.params.id)
+      const dstTasks = db.prepare(
+        'SELECT id FROM tasks WHERE column_id = ? ORDER BY position'
+      ).all(dstColId).map(t => t.id)
+
+      dstTasks.splice(targetPosition, 0, req.params.id)
+
+      db.prepare('UPDATE tasks SET column_id = ?, board_id = (SELECT board_id FROM columns WHERE id = ?) WHERE id = ?')
+        .run(dstColId, dstColId, req.params.id)
+
+      const upd = db.prepare('UPDATE tasks SET position = ? WHERE id = ?')
+      srcTasks.forEach((id, i) => upd.run(i, id))
+      dstTasks.forEach((id, i) => upd.run(i, id))
+    }
+  })()
+
+  log.info(`Moved task ${req.params.id} → col=${dstColId} pos=${targetPosition}`)
+  res.json({ ok: true })
+})
+
+// POST /api/tasks/:id/sub-board — create a new sub-board for this task
+router.post('/tasks/:id/sub-board', (req, res) => {
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id)
+  if (!task) return res.status(404).json({ error: 'Task not found' })
+  if (task.sub_board_id) {
+    return res.json({ boardId: task.sub_board_id, existing: true })
+  }
+
+  const boardId = `board_${req.params.id}`
+
+  db.transaction(() => {
+    db.prepare('INSERT INTO boards (id, title, parent_task_id) VALUES (?, ?, ?)')
+      .run(boardId, task.title, task.id)
+
+    const insertCol = db.prepare(
+      'INSERT INTO columns (id, board_id, title, position, allow_new_tasks) VALUES (?, ?, ?, ?, ?)'
+    )
+    insertCol.run(`${boardId}_todo`,        boardId, 'To Do',       0, 1)
+    insertCol.run(`${boardId}_inProgress`,  boardId, 'In Progress', 1, 0)
+    insertCol.run(`${boardId}_done`,        boardId, 'Done',        2, 0)
+
+    db.prepare('UPDATE tasks SET sub_board_id = ?, updated_at = datetime(\'now\') WHERE id = ?')
+      .run(boardId, task.id)
+  })()
+
+  log.info(`Created sub-board ${boardId} for task ${req.params.id}`)
+  res.status(201).json({ boardId, existing: false })
+})
+
+module.exports = router

--- a/server/routes/vdiagram.js
+++ b/server/routes/vdiagram.js
@@ -1,0 +1,170 @@
+// V-diagram: requirements, verifications, and their links
+
+const { Router } = require('express')
+const { randomUUID } = require('crypto')
+const db  = require('../db')
+const log = require('../logger')
+
+const router = Router()
+
+// ── GET full V-diagram for a task ─────────────────────────────────────────
+
+router.get('/tasks/:id/vdiagram', (req, res) => {
+  const task = db.prepare('SELECT id, title FROM tasks WHERE id = ?').get(req.params.id)
+  if (!task) return res.status(404).json({ error: 'Task not found' })
+
+  const requirements = db.prepare(
+    'SELECT * FROM requirements WHERE task_id = ? ORDER BY position'
+  ).all(req.params.id)
+
+  const verifications = db.prepare(
+    'SELECT * FROM verifications WHERE task_id = ? ORDER BY position'
+  ).all(req.params.id)
+
+  const links = db.prepare(`
+    SELECT rl.requirement_id, rl.verification_id
+    FROM req_ver_links rl
+    JOIN requirements r ON r.id = rl.requirement_id
+    WHERE r.task_id = ?
+  `).all(req.params.id)
+
+  // Summary: how many verifications are passing
+  const passed  = verifications.filter(v => v.status === 'passed').length
+  const failed  = verifications.filter(v => v.status === 'failed').length
+  const covered = new Set(links.map(l => l.requirement_id)).size
+
+  res.json({
+    task,
+    requirements,
+    verifications,
+    links,
+    summary: {
+      requirementCount: requirements.length,
+      verificationCount: verifications.length,
+      covered,
+      passed,
+      failed,
+    },
+  })
+})
+
+// ── Requirements CRUD ────────────────────────────────────────────────────
+
+router.post('/tasks/:id/requirements', (req, res) => {
+  const { text, priority = 'medium', source } = req.body
+  if (!text) return res.status(400).json({ error: 'text required' })
+
+  const maxPos = db.prepare(
+    'SELECT COALESCE(MAX(position), -1) AS m FROM requirements WHERE task_id = ?'
+  ).get(req.params.id).m
+
+  const id = randomUUID()
+  db.prepare(
+    'INSERT INTO requirements (id, task_id, text, priority, source, position) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(id, req.params.id, text, priority, source || null, maxPos + 1)
+
+  log.info(`Created requirement ${id} on task ${req.params.id}`)
+  res.status(201).json(db.prepare('SELECT * FROM requirements WHERE id = ?').get(id))
+})
+
+router.patch('/requirements/:id', (req, res) => {
+  const req_ = db.prepare('SELECT * FROM requirements WHERE id = ?').get(req.params.id)
+  if (!req_) return res.status(404).json({ error: 'Not found' })
+
+  const { text, priority, source } = req.body
+  db.prepare(`
+    UPDATE requirements SET
+      text     = COALESCE(?, text),
+      priority = COALESCE(?, priority),
+      source   = COALESCE(?, source)
+    WHERE id = ?
+  `).run(text || null, priority || null, source || null, req.params.id)
+
+  res.json(db.prepare('SELECT * FROM requirements WHERE id = ?').get(req.params.id))
+})
+
+router.delete('/requirements/:id', (req, res) => {
+  if (!db.prepare('SELECT 1 FROM requirements WHERE id = ?').get(req.params.id))
+    return res.status(404).json({ error: 'Not found' })
+  db.prepare('DELETE FROM requirements WHERE id = ?').run(req.params.id)
+  log.info(`Deleted requirement ${req.params.id}`)
+  res.status(204).end()
+})
+
+// ── Verifications CRUD ──────────────────────────────────────────────────
+
+router.post('/tasks/:id/verifications', (req, res) => {
+  const { text, type = 'manual' } = req.body
+  if (!text) return res.status(400).json({ error: 'text required' })
+
+  const maxPos = db.prepare(
+    'SELECT COALESCE(MAX(position), -1) AS m FROM verifications WHERE task_id = ?'
+  ).get(req.params.id).m
+
+  const id = randomUUID()
+  db.prepare(
+    'INSERT INTO verifications (id, task_id, text, type, status, position) VALUES (?, ?, ?, ?, \'pending\', ?)'
+  ).run(id, req.params.id, text, type, maxPos + 1)
+
+  log.info(`Created verification ${id} on task ${req.params.id}`)
+  res.status(201).json(db.prepare('SELECT * FROM verifications WHERE id = ?').get(id))
+})
+
+router.patch('/verifications/:id', (req, res) => {
+  const ver = db.prepare('SELECT * FROM verifications WHERE id = ?').get(req.params.id)
+  if (!ver) return res.status(404).json({ error: 'Not found' })
+
+  const { text, type, status, result_notes } = req.body
+  const verifiedAt = status === 'passed' || status === 'failed'
+    ? new Date().toISOString()
+    : ver.verified_at
+
+  db.prepare(`
+    UPDATE verifications SET
+      text         = COALESCE(?, text),
+      type         = COALESCE(?, type),
+      status       = COALESCE(?, status),
+      result_notes = COALESCE(?, result_notes),
+      verified_at  = ?
+    WHERE id = ?
+  `).run(text || null, type || null, status || null, result_notes || null, verifiedAt, req.params.id)
+
+  log.info(`Updated verification ${req.params.id} → ${status || ver.status}`)
+  res.json(db.prepare('SELECT * FROM verifications WHERE id = ?').get(req.params.id))
+})
+
+router.delete('/verifications/:id', (req, res) => {
+  if (!db.prepare('SELECT 1 FROM verifications WHERE id = ?').get(req.params.id))
+    return res.status(404).json({ error: 'Not found' })
+  db.prepare('DELETE FROM verifications WHERE id = ?').run(req.params.id)
+  log.info(`Deleted verification ${req.params.id}`)
+  res.status(204).end()
+})
+
+// ── Link / unlink ─────────────────────────────────────────────────────────
+
+// POST /api/requirements/:reqId/link/:verId
+router.post('/requirements/:reqId/link/:verId', (req, res) => {
+  const { reqId, verId } = req.params
+  if (!db.prepare('SELECT 1 FROM requirements WHERE id = ?').get(reqId))
+    return res.status(404).json({ error: 'Requirement not found' })
+  if (!db.prepare('SELECT 1 FROM verifications WHERE id = ?').get(verId))
+    return res.status(404).json({ error: 'Verification not found' })
+
+  db.prepare(
+    'INSERT OR IGNORE INTO req_ver_links (requirement_id, verification_id) VALUES (?, ?)'
+  ).run(reqId, verId)
+
+  log.info(`Linked req ${reqId} → ver ${verId}`)
+  res.status(201).json({ requirement_id: reqId, verification_id: verId })
+})
+
+// DELETE /api/requirements/:reqId/link/:verId
+router.delete('/requirements/:reqId/link/:verId', (req, res) => {
+  db.prepare(
+    'DELETE FROM req_ver_links WHERE requirement_id = ? AND verification_id = ?'
+  ).run(req.params.reqId, req.params.verId)
+  res.status(204).end()
+})
+
+module.exports = router

--- a/server/sse.js
+++ b/server/sse.js
@@ -1,0 +1,24 @@
+// Server-Sent Events broadcaster — shared between routes and automation runner
+
+const clients = new Set()
+
+function addClient(res) {
+  clients.add(res)
+}
+
+function removeClient(res) {
+  clients.delete(res)
+}
+
+function broadcast(event, data) {
+  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+  for (const client of clients) {
+    try {
+      client.write(payload)
+    } catch {
+      clients.delete(client)
+    }
+  }
+}
+
+module.exports = { addClient, removeClient, broadcast }

--- a/src/AutomationCard.jsx
+++ b/src/AutomationCard.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
 import { triggerAutomation, getAutomationLogs } from './api'
 import { log } from './logger'
+import VDiagram from './VDiagram'
 
 const STATUS_ICON = {
   pending:  { icon: '◌', cls: 'status-pending'  },
@@ -98,6 +99,7 @@ function AutomationDetail({ automation, liveStatus, onClose }) {
 
 export default function AutomationCard({ task, index, liveStatuses, onDelete }) {
   const [expanded, setExpanded] = useState(false)
+  const [showVD,   setShowVD]   = useState(false)
 
   // A task in the automation column may have multiple automations
   const automations = task.automations || []
@@ -108,6 +110,7 @@ export default function AutomationCard({ task, index, liveStatuses, onDelete }) 
   const si      = STATUS_ICON[status] || STATUS_ICON.pending
 
   return (
+    <>
     <Draggable draggableId={task.id} index={index}>
       {(provided, snapshot) => (
         <div
@@ -122,6 +125,13 @@ export default function AutomationCard({ task, index, liveStatuses, onDelete }) 
               {task.due_date && <span className="tag due-tag">{task.due_date}</span>}
             </div>
             <div className="card-actions">
+              <button
+                className="btn-vd"
+                onClick={(e) => { e.stopPropagation(); setShowVD(true) }}
+                title="V-diagram: requirements & verification"
+              >
+                V
+              </button>
               {primaryAuto && (
                 <button
                   className="btn-auto-expand"
@@ -172,5 +182,14 @@ export default function AutomationCard({ task, index, liveStatuses, onDelete }) 
         </div>
       )}
     </Draggable>
+
+    {showVD && (
+      <VDiagram
+        taskId={task.id}
+        taskTitle={task.title}
+        onClose={() => setShowVD(false)}
+      />
+    )}
+    </>
   )
 }

--- a/src/AutomationCard.jsx
+++ b/src/AutomationCard.jsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react'
+import { Draggable } from 'react-beautiful-dnd'
+import { triggerAutomation, getAutomationLogs } from './api'
+import { log } from './logger'
+
+const STATUS_ICON = {
+  pending:  { icon: '◌', cls: 'status-pending'  },
+  running:  { icon: '⟳', cls: 'status-running'  },
+  success:  { icon: '●', cls: 'status-success'  },
+  failure:  { icon: '●', cls: 'status-failure'  },
+  error:    { icon: '●', cls: 'status-error'     },
+}
+
+const TYPE_LABEL = {
+  http_check:    'HTTP Check',
+  process_check: 'Process Check',
+  cron:          'Cron Job',
+  webhook:       'Webhook',
+}
+
+function AutomationDetail({ automation, liveStatus, onClose }) {
+  const [logs, setLogs]     = useState(null)
+  const [running, setRunning] = useState(false)
+
+  const status = liveStatus?.status || automation.status || 'pending'
+  const lastResult = liveStatus?.result
+    ? liveStatus.result
+    : automation.last_result
+      ? (typeof automation.last_result === 'string'
+          ? JSON.parse(automation.last_result)
+          : automation.last_result)
+      : null
+
+  const loadLogs = async () => {
+    const data = await getAutomationLogs(automation.id)
+    setLogs(data)
+  }
+
+  const handleTrigger = async () => {
+    setRunning(true)
+    try {
+      await triggerAutomation(automation.id)
+      log('Manual trigger sent', automation.id)
+    } catch (e) {
+      log('Trigger failed', e.message)
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <div className="auto-detail">
+      <div className="auto-detail-header">
+        <span className="auto-detail-title">{automation.name}</span>
+        <button className="auto-detail-close" onClick={onClose}>×</button>
+      </div>
+      <div className="auto-detail-meta">
+        <span className="tag type-tag">{TYPE_LABEL[automation.type] || automation.type}</span>
+        <span className={`auto-status-dot ${(STATUS_ICON[status] || STATUS_ICON.pending).cls}`}>
+          {(STATUS_ICON[status] || STATUS_ICON.pending).icon}
+        </span>
+        <span className="auto-status-text">{status}</span>
+      </div>
+      <div className="auto-detail-schedule">⏱ {automation.schedule}</div>
+      {automation.last_run && (
+        <div className="auto-detail-lastrun">
+          Last run: {new Date(automation.last_run).toLocaleTimeString()}
+        </div>
+      )}
+      {lastResult && (
+        <pre className="auto-result">
+          {JSON.stringify(lastResult, null, 2)}
+        </pre>
+      )}
+      <div className="auto-detail-actions">
+        <button className="btn-trigger" onClick={handleTrigger} disabled={running}>
+          {running ? 'Running…' : '▶ Run now'}
+        </button>
+        <button className="btn-view-logs" onClick={loadLogs}>
+          View logs
+        </button>
+      </div>
+      {logs && (
+        <div className="auto-logs">
+          {logs.length === 0 && <div className="auto-log-empty">No runs yet</div>}
+          {logs.map(l => (
+            <div key={l.id} className={`auto-log-row log-${l.status}`}>
+              <span className="log-time">{l.run_at.slice(11, 19)}</span>
+              <span className={`log-status ${l.status}`}>{l.status}</span>
+              {l.duration_ms && <span className="log-dur">{l.duration_ms}ms</span>}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function AutomationCard({ task, index, liveStatuses, onDelete }) {
+  const [expanded, setExpanded] = useState(false)
+
+  // A task in the automation column may have multiple automations
+  const automations = task.automations || []
+  const primaryAuto = automations[0] || null
+  const liveStatus  = primaryAuto ? liveStatuses[primaryAuto.id] : null
+
+  const status  = liveStatus?.status || primaryAuto?.status || (automations.length ? 'pending' : null)
+  const si      = STATUS_ICON[status] || STATUS_ICON.pending
+
+  return (
+    <Draggable draggableId={task.id} index={index}>
+      {(provided, snapshot) => (
+        <div
+          className={`card automation-card${snapshot.isDragging ? ' dragging' : ''}${status ? ` border-${status}` : ''}`}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <div className="card-header">
+            <div className="card-meta">
+              {task.repeat_pattern && <span className="tag repeat-tag">{task.repeat_pattern}</span>}
+              {task.due_date && <span className="tag due-tag">{task.due_date}</span>}
+            </div>
+            <div className="card-actions">
+              {primaryAuto && (
+                <button
+                  className="btn-auto-expand"
+                  onClick={(e) => { e.stopPropagation(); setExpanded(x => !x) }}
+                  title="Automation details"
+                >
+                  ⚙
+                </button>
+              )}
+              <button
+                className="btn-delete"
+                onClick={(e) => { e.stopPropagation(); onDelete() }}
+                title="Delete task"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+
+          <div className="auto-task-row">
+            {status && (
+              <span className={`auto-status-dot ${si.cls}`} title={status}>{si.icon}</span>
+            )}
+            <div className="card-title">{task.title}</div>
+          </div>
+
+          {automations.length > 0 && (
+            <div className="auto-badges">
+              {automations.map(a => (
+                <span key={a.id} className="tag type-tag">
+                  {TYPE_LABEL[a.type] || a.type}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {automations.length === 0 && (
+            <div className="auto-none-hint">No automation configured</div>
+          )}
+
+          {expanded && primaryAuto && (
+            <AutomationDetail
+              automation={primaryAuto}
+              liveStatus={liveStatus}
+              onClose={() => setExpanded(false)}
+            />
+          )}
+        </div>
+      )}
+    </Draggable>
+  )
+}

--- a/src/AutomationForm.jsx
+++ b/src/AutomationForm.jsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react'
+import { createAutomation } from './api'
+import { log, warn } from './logger'
+
+const TYPES = [
+  { value: 'http_check',    label: 'HTTP Check',    desc: 'Poll a URL and verify the response' },
+  { value: 'process_check', label: 'Process/Port',  desc: 'Check if a local port or process is running' },
+  { value: 'cron',          label: 'Cron Command',  desc: 'Run a shell command on a schedule' },
+  { value: 'webhook',       label: 'Webhook',       desc: 'Receive HTTP events from external systems' },
+]
+
+function HttpConfig({ config, onChange }) {
+  return (
+    <div className="auto-config-fields">
+      <label>URL
+        <input type="url" value={config.url || ''} placeholder="https://example.com/health"
+          onChange={e => onChange({ ...config, url: e.target.value })} />
+      </label>
+      <label>Expected status
+        <input type="number" value={config.expectedStatus || 200} min="100" max="599"
+          onChange={e => onChange({ ...config, expectedStatus: parseInt(e.target.value) })} />
+      </label>
+      <label>Timeout (ms)
+        <input type="number" value={config.timeout || 5000} min="500" max="30000" step="500"
+          onChange={e => onChange({ ...config, timeout: parseInt(e.target.value) })} />
+      </label>
+    </div>
+  )
+}
+
+function ProcessConfig({ config, onChange }) {
+  return (
+    <div className="auto-config-fields">
+      <label>Check type
+        <select value={config.checkType || 'port'} onChange={e => onChange({ ...config, checkType: e.target.value })}>
+          <option value="port">Port</option>
+          <option value="process">Process name</option>
+        </select>
+      </label>
+      {(config.checkType || 'port') === 'port' ? (
+        <>
+          <label>Host
+            <input type="text" value={config.host || 'localhost'}
+              onChange={e => onChange({ ...config, host: e.target.value })} />
+          </label>
+          <label>Port
+            <input type="number" value={config.port || ''} placeholder="8080" min="1" max="65535"
+              onChange={e => onChange({ ...config, port: parseInt(e.target.value) })} />
+          </label>
+        </>
+      ) : (
+        <label>Process name
+          <input type="text" value={config.processName || ''} placeholder="nginx"
+            onChange={e => onChange({ ...config, processName: e.target.value })} />
+        </label>
+      )}
+    </div>
+  )
+}
+
+function CronConfig({ config, onChange }) {
+  return (
+    <div className="auto-config-fields">
+      <label>Shell command
+        <input type="text" value={config.command || ''} placeholder="echo hello"
+          onChange={e => onChange({ ...config, command: e.target.value })} />
+      </label>
+      <label>Timeout (ms)
+        <input type="number" value={config.timeout || 30000} min="1000" max="300000" step="1000"
+          onChange={e => onChange({ ...config, timeout: parseInt(e.target.value) })} />
+      </label>
+    </div>
+  )
+}
+
+function WebhookConfig({ taskId }) {
+  const url = `${window.location.origin}/webhooks/${taskId}`
+  return (
+    <div className="auto-config-fields">
+      <label>Webhook URL (send POST requests here)
+        <div className="webhook-url-row">
+          <code className="webhook-url">{url}</code>
+          <button type="button" onClick={() => navigator.clipboard.writeText(url)}>Copy</button>
+        </div>
+      </label>
+      <p className="auto-hint">External systems POST JSON to this URL to update the task status.</p>
+    </div>
+  )
+}
+
+export default function AutomationForm({ task, onCreated, onCancel }) {
+  const [name,     setName]     = useState(task.title + ' monitor')
+  const [type,     setType]     = useState('http_check')
+  const [config,   setConfig]   = useState({ url: '', expectedStatus: 200, timeout: 5000 })
+  const [schedule, setSchedule] = useState('*/5 * * * *')
+  const [saving,   setSaving]   = useState(false)
+  const [error,    setError]    = useState(null)
+
+  const handleTypeChange = (t) => {
+    setType(t)
+    const defaults = {
+      http_check:    { url: '', expectedStatus: 200, timeout: 5000 },
+      process_check: { checkType: 'port', host: 'localhost', port: '' },
+      cron:          { command: '', timeout: 30000 },
+      webhook:       {},
+    }
+    setConfig(defaults[t] || {})
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!name.trim()) { warn('AutomationForm: name required'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      const auto = await createAutomation({ taskId: task.id, name, type, config, schedule })
+      log('Created automation', auto.id)
+      onCreated(auto)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <form className="automation-form" onSubmit={handleSubmit}>
+      <div className="auto-form-header">
+        <span>Add automation</span>
+        <button type="button" className="btn-cancel-icon" onClick={onCancel}>×</button>
+      </div>
+
+      <label>Name
+        <input type="text" value={name} onChange={e => setName(e.target.value)} required />
+      </label>
+
+      <label>Type
+        <select value={type} onChange={e => handleTypeChange(e.target.value)}>
+          {TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+        </select>
+      </label>
+
+      {type === 'http_check'    && <HttpConfig    config={config} onChange={setConfig} />}
+      {type === 'process_check' && <ProcessConfig config={config} onChange={setConfig} />}
+      {type === 'cron'          && <CronConfig    config={config} onChange={setConfig} />}
+      {type === 'webhook'       && <WebhookConfig taskId={task.id} />}
+
+      {type !== 'webhook' && (
+        <label>Schedule (cron)
+          <input type="text" value={schedule} placeholder="*/5 * * * *"
+            onChange={e => setSchedule(e.target.value)} />
+          <span className="auto-hint">e.g. */5 * * * * = every 5 min, 0 9 * * 1 = Mon 9am</span>
+        </label>
+      )}
+
+      {error && <div className="auto-form-error">{error}</div>}
+
+      <div className="auto-form-btns">
+        <button type="submit" className="btn-submit" disabled={saving}>
+          {saving ? 'Saving…' : 'Save automation'}
+        </button>
+        <button type="button" className="btn-cancel" onClick={onCancel}>Cancel</button>
+      </div>
+    </form>
+  )
+}

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { DragDropContext } from 'react-beautiful-dnd'
+import Lane from './lane'
+
+export default function Board({ boardId, board, tasks, onMoveTask, onAddTask, onDeleteTask, onDrillIn }) {
+  const onDragEnd = (result) => {
+    if (!result.destination) return
+    onMoveTask(boardId, result.source, result.destination)
+  }
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <div className="laneGroup">
+        {board.columnOrder.map((colId) => {
+          const column = board.columns[colId]
+          const columnTasks = (column.tasks || [])
+            .map((taskId) => tasks[taskId])
+            .filter(Boolean)
+          const hasNewTaskForm = (board.newTaskColumns || []).includes(colId)
+          return (
+            <Lane
+              key={colId}
+              column={column}
+              tasks={columnTasks}
+              hasNewTaskForm={hasNewTaskForm}
+              onAddTask={(taskData) => onAddTask(boardId, colId, taskData)}
+              onDeleteTask={(taskId) => onDeleteTask(boardId, colId, taskId)}
+              onDrillIn={onDrillIn}
+            />
+          )
+        })}
+      </div>
+    </DragDropContext>
+  )
+}

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -3,37 +3,34 @@ import { DragDropContext } from 'react-beautiful-dnd'
 import Lane from './lane'
 import { log, warn } from './logger'
 
-export default function Board({ boardId, board, tasks, onMoveTask, onAddTask, onDeleteTask, onDrillIn }) {
+export default function Board({ board, liveStatuses, onMoveTask, onAddTask, onDeleteTask, onDrillIn }) {
   const onDragEnd = (result) => {
     if (!result.destination) {
-      warn('onDragEnd: no destination, drag cancelled', { draggableId: result.draggableId })
+      warn('onDragEnd: drag cancelled, no destination', result.draggableId)
       return
     }
-    log('onDragEnd', { draggableId: result.draggableId, source: result.source, destination: result.destination })
-    onMoveTask(boardId, result.source, result.destination)
+    log('onDragEnd', {
+      task: result.draggableId,
+      from: `${result.source.droppableId}[${result.source.index}]`,
+      to:   `${result.destination.droppableId}[${result.destination.index}]`,
+    })
+    onMoveTask(result.draggableId, result.destination.droppableId, result.destination.index)
   }
 
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <div className="laneGroup">
-        {board.columnOrder.map((colId) => {
-          const column = board.columns[colId]
-          const columnTasks = (column.tasks || [])
-            .map((taskId) => tasks[taskId])
-            .filter(Boolean)
-          const hasNewTaskForm = (board.newTaskColumns || []).includes(colId)
-          return (
-            <Lane
-              key={colId}
-              column={column}
-              tasks={columnTasks}
-              hasNewTaskForm={hasNewTaskForm}
-              onAddTask={(taskData) => onAddTask(boardId, colId, taskData)}
-              onDeleteTask={(taskId) => onDeleteTask(boardId, colId, taskId)}
-              onDrillIn={onDrillIn}
-            />
-          )
-        })}
+        {board.columns.map(column => (
+          <Lane
+            key={column.id}
+            column={column}
+            tasks={column.tasks}
+            liveStatuses={liveStatuses}
+            onAddTask={(data) => onAddTask(board.id, column.id, data)}
+            onDeleteTask={onDeleteTask}
+            onDrillIn={onDrillIn}
+          />
+        ))}
       </div>
     </DragDropContext>
   )

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -1,10 +1,15 @@
 import React from 'react'
 import { DragDropContext } from 'react-beautiful-dnd'
 import Lane from './lane'
+import { log, warn } from './logger'
 
 export default function Board({ boardId, board, tasks, onMoveTask, onAddTask, onDeleteTask, onDrillIn }) {
   const onDragEnd = (result) => {
-    if (!result.destination) return
+    if (!result.destination) {
+      warn('onDragEnd: no destination, drag cancelled', { draggableId: result.draggableId })
+      return
+    }
+    log('onDragEnd', { draggableId: result.draggableId, source: result.source, destination: result.destination })
     onMoveTask(boardId, result.source, result.destination)
   }
 

--- a/src/NewTaskForm.jsx
+++ b/src/NewTaskForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { log, warn } from './logger'
 
 export default function NewTaskForm({ onAdd }) {
   const [expanded, setExpanded] = useState(false)
@@ -7,7 +8,11 @@ export default function NewTaskForm({ onAdd }) {
 
   const handleSubmit = (e) => {
     e.preventDefault()
-    if (!title.trim()) return
+    if (!title.trim()) {
+      warn('NewTaskForm: submit blocked — title is empty')
+      return
+    }
+    log('NewTaskForm: submitting', { title: title.trim(), due: due || null })
     onAdd({ title: title.trim(), due: due || null })
     setTitle('')
     setDue('')

--- a/src/NewTaskForm.jsx
+++ b/src/NewTaskForm.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+
+export default function NewTaskForm({ onAdd }) {
+  const [expanded, setExpanded] = useState(false)
+  const [title, setTitle] = useState('')
+  const [due, setDue] = useState('')
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (!title.trim()) return
+    onAdd({ title: title.trim(), due: due || null })
+    setTitle('')
+    setDue('')
+    setExpanded(false)
+  }
+
+  const handleCancel = () => {
+    setTitle('')
+    setDue('')
+    setExpanded(false)
+  }
+
+  if (!expanded) {
+    return (
+      <button className="add-task-btn" onClick={() => setExpanded(true)}>
+        + Add task
+      </button>
+    )
+  }
+
+  return (
+    <form className="new-task-form" onSubmit={handleSubmit}>
+      <input
+        autoFocus
+        className="input-title"
+        type="text"
+        placeholder="Task title..."
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={(e) => e.key === 'Escape' && handleCancel()}
+      />
+      <div className="form-row">
+        <input
+          className="input-date"
+          type="date"
+          value={due}
+          onChange={(e) => setDue(e.target.value)}
+        />
+        <button type="submit" className="btn-submit">
+          Add
+        </button>
+        <button type="button" className="btn-cancel" onClick={handleCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Draggable } from 'react-beautiful-dnd'
+
+export default function TaskCard({ task, index, onDelete, onDrillIn }) {
+  return (
+    <Draggable draggableId={task.id} index={index}>
+      {(provided, snapshot) => (
+        <div
+          className={`card${snapshot.isDragging ? ' dragging' : ''}${task.boardId ? ' has-subboard' : ''}`}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <div className="card-header">
+            <div className="card-meta">
+              {task.repeat && <span className="tag repeat-tag">{task.repeat}</span>}
+              {task.due && <span className="tag due-tag">{task.due}</span>}
+            </div>
+            <div className="card-actions">
+              <button
+                className={`btn-drill${task.boardId ? ' active' : ''}`}
+                onClick={(e) => { e.stopPropagation(); onDrillIn() }}
+                title={task.boardId ? 'Open sub-board' : 'Create sub-board'}
+              >
+                {task.boardId ? '⊞' : '⊟'}
+              </button>
+              <button
+                className="btn-delete"
+                onClick={(e) => { e.stopPropagation(); onDelete() }}
+                title="Delete task"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+          <div className="card-title">{task.title}</div>
+          {task.description && (
+            <div className="card-description">{task.description}</div>
+          )}
+          {task.boardId && (
+            <div className="subboard-indicator" onClick={(e) => { e.stopPropagation(); onDrillIn() }}>
+              View board →
+            </div>
+          )}
+        </div>
+      )}
+    </Draggable>
+  )
+}

--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -1,47 +1,67 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
+import VDiagram from './VDiagram'
 
 export default function TaskCard({ task, index, onDelete, onDrillIn }) {
+  const [showVD, setShowVD] = useState(false)
+
   return (
-    <Draggable draggableId={task.id} index={index}>
-      {(provided, snapshot) => (
-        <div
-          className={`card${snapshot.isDragging ? ' dragging' : ''}${task.sub_board_id ? ' has-subboard' : ''}`}
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-        >
-          <div className="card-header">
-            <div className="card-meta">
-              {task.repeat_pattern && <span className="tag repeat-tag">{task.repeat_pattern}</span>}
-              {task.due_date && <span className="tag due-tag">{task.due_date}</span>}
+    <>
+      <Draggable draggableId={task.id} index={index}>
+        {(provided, snapshot) => (
+          <div
+            className={`card${snapshot.isDragging ? ' dragging' : ''}${task.sub_board_id ? ' has-subboard' : ''}`}
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+          >
+            <div className="card-header">
+              <div className="card-meta">
+                {task.repeat_pattern && <span className="tag repeat-tag">{task.repeat_pattern}</span>}
+                {task.due_date && <span className="tag due-tag">{task.due_date}</span>}
+              </div>
+              <div className="card-actions">
+                <button
+                  className="btn-vd"
+                  onClick={e => { e.stopPropagation(); setShowVD(true) }}
+                  title="V-diagram: requirements & verification"
+                >
+                  V
+                </button>
+                <button
+                  className={`btn-drill${task.sub_board_id ? ' active' : ''}`}
+                  onClick={e => { e.stopPropagation(); onDrillIn() }}
+                  title={task.sub_board_id ? 'Open sub-board' : 'Create sub-board'}
+                >
+                  {task.sub_board_id ? '⊞' : '⊟'}
+                </button>
+                <button
+                  className="btn-delete"
+                  onClick={e => { e.stopPropagation(); onDelete() }}
+                  title="Delete task"
+                >
+                  ×
+                </button>
+              </div>
             </div>
-            <div className="card-actions">
-              <button
-                className={`btn-drill${task.sub_board_id ? ' active' : ''}`}
-                onClick={e => { e.stopPropagation(); onDrillIn() }}
-                title={task.sub_board_id ? 'Open sub-board' : 'Create sub-board'}
-              >
-                {task.sub_board_id ? '⊞' : '⊟'}
-              </button>
-              <button
-                className="btn-delete"
-                onClick={e => { e.stopPropagation(); onDelete() }}
-                title="Delete task"
-              >
-                ×
-              </button>
-            </div>
+            <div className="card-title">{task.title}</div>
+            {task.description && <div className="card-description">{task.description}</div>}
+            {task.sub_board_id && (
+              <div className="subboard-indicator" onClick={e => { e.stopPropagation(); onDrillIn() }}>
+                View board →
+              </div>
+            )}
           </div>
-          <div className="card-title">{task.title}</div>
-          {task.description && <div className="card-description">{task.description}</div>}
-          {task.sub_board_id && (
-            <div className="subboard-indicator" onClick={e => { e.stopPropagation(); onDrillIn() }}>
-              View board →
-            </div>
-          )}
-        </div>
+        )}
+      </Draggable>
+
+      {showVD && (
+        <VDiagram
+          taskId={task.id}
+          taskTitle={task.title}
+          onClose={() => setShowVD(false)}
+        />
       )}
-    </Draggable>
+    </>
   )
 }

--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -6,27 +6,27 @@ export default function TaskCard({ task, index, onDelete, onDrillIn }) {
     <Draggable draggableId={task.id} index={index}>
       {(provided, snapshot) => (
         <div
-          className={`card${snapshot.isDragging ? ' dragging' : ''}${task.boardId ? ' has-subboard' : ''}`}
+          className={`card${snapshot.isDragging ? ' dragging' : ''}${task.sub_board_id ? ' has-subboard' : ''}`}
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
         >
           <div className="card-header">
             <div className="card-meta">
-              {task.repeat && <span className="tag repeat-tag">{task.repeat}</span>}
-              {task.due && <span className="tag due-tag">{task.due}</span>}
+              {task.repeat_pattern && <span className="tag repeat-tag">{task.repeat_pattern}</span>}
+              {task.due_date && <span className="tag due-tag">{task.due_date}</span>}
             </div>
             <div className="card-actions">
               <button
-                className={`btn-drill${task.boardId ? ' active' : ''}`}
-                onClick={(e) => { e.stopPropagation(); onDrillIn() }}
-                title={task.boardId ? 'Open sub-board' : 'Create sub-board'}
+                className={`btn-drill${task.sub_board_id ? ' active' : ''}`}
+                onClick={e => { e.stopPropagation(); onDrillIn() }}
+                title={task.sub_board_id ? 'Open sub-board' : 'Create sub-board'}
               >
-                {task.boardId ? '⊞' : '⊟'}
+                {task.sub_board_id ? '⊞' : '⊟'}
               </button>
               <button
                 className="btn-delete"
-                onClick={(e) => { e.stopPropagation(); onDelete() }}
+                onClick={e => { e.stopPropagation(); onDelete() }}
                 title="Delete task"
               >
                 ×
@@ -34,11 +34,9 @@ export default function TaskCard({ task, index, onDelete, onDrillIn }) {
             </div>
           </div>
           <div className="card-title">{task.title}</div>
-          {task.description && (
-            <div className="card-description">{task.description}</div>
-          )}
-          {task.boardId && (
-            <div className="subboard-indicator" onClick={(e) => { e.stopPropagation(); onDrillIn() }}>
+          {task.description && <div className="card-description">{task.description}</div>}
+          {task.sub_board_id && (
+            <div className="subboard-indicator" onClick={e => { e.stopPropagation(); onDrillIn() }}>
               View board →
             </div>
           )}

--- a/src/VDiagram.jsx
+++ b/src/VDiagram.jsx
@@ -1,0 +1,386 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import {
+  getVDiagram,
+  addRequirement, updateRequirement, deleteRequirement,
+  addVerification, updateVerification, deleteVerification,
+  linkReqVer, unlinkReqVer,
+} from './api'
+import { log, warn } from './logger'
+
+// ── Status helpers ─────────────────────────────────────────────────────────
+
+const VER_STATUS = {
+  pending:     { icon: '○', label: 'Pending',     cls: 'vs-pending'     },
+  in_progress: { icon: '◑', label: 'In progress', cls: 'vs-in-progress' },
+  passed:      { icon: '●', label: 'Passed',       cls: 'vs-passed'      },
+  failed:      { icon: '●', label: 'Failed',        cls: 'vs-failed'      },
+}
+
+const PRI_CLS = { high: 'pri-high', medium: 'pri-medium', low: 'pri-low' }
+
+const VER_TYPES = ['manual', 'automated', 'inspection', 'demonstration']
+
+// Status cycle: pending → in_progress → passed → failed → pending
+const NEXT_STATUS = {
+  pending: 'in_progress', in_progress: 'passed', passed: 'failed', failed: 'pending',
+}
+
+// ── Line renderer ──────────────────────────────────────────────────────────
+
+function Lines({ links, reqRefs, verRefs, containerRef, selectedReqId }) {
+  const [paths, setPaths] = useState([])
+
+  const compute = useCallback(() => {
+    if (!containerRef.current) return
+    const box = containerRef.current.getBoundingClientRect()
+    const next = []
+    for (const lk of links) {
+      const rEl = reqRefs.current[lk.requirement_id]
+      const vEl = verRefs.current[lk.verification_id]
+      if (!rEl || !vEl) continue
+      const r = rEl.getBoundingClientRect()
+      const v = vEl.getBoundingClientRect()
+      const x1 = r.right  - box.left
+      const y1 = r.top    + r.height / 2 - box.top
+      const x2 = v.left   - box.left
+      const y2 = v.top    + v.height / 2 - box.top
+      // Cubic bezier — control points curve toward the center
+      const cx = (x1 + x2) / 2
+      next.push({
+        d: `M${x1},${y1} C${cx},${y1} ${cx},${y2} ${x2},${y2}`,
+        highlighted: lk.requirement_id === selectedReqId,
+        key: `${lk.requirement_id}-${lk.verification_id}`,
+      })
+    }
+    setPaths(next)
+  }, [links, reqRefs, verRefs, containerRef, selectedReqId])
+
+  useEffect(() => {
+    // Delay slightly so DOM has settled after render
+    const id = setTimeout(compute, 60)
+    return () => clearTimeout(id)
+  }, [compute])
+
+  // Also recompute on window resize
+  useEffect(() => {
+    window.addEventListener('resize', compute)
+    return () => window.removeEventListener('resize', compute)
+  }, [compute])
+
+  return (
+    <svg className="vd-svg" aria-hidden="true">
+      <defs>
+        <marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L6,3 z" fill="var(--link-color)" />
+        </marker>
+      </defs>
+      {paths.map(p => (
+        <path
+          key={p.key}
+          d={p.d}
+          className={`vd-link${p.highlighted ? ' vd-link-hi' : ''}`}
+          markerEnd="url(#arrow)"
+        />
+      ))}
+    </svg>
+  )
+}
+
+// ── Inline edit row ────────────────────────────────────────────────────────
+
+function InlineAdd({ placeholder, onAdd, onCancel, extraFields }) {
+  const [text, setText] = useState('')
+  const [extra, setExtra] = useState(extraFields ? Object.fromEntries(extraFields.map(f => [f.key, f.default])) : {})
+
+  const submit = (e) => {
+    e.preventDefault()
+    if (!text.trim()) return
+    onAdd({ text: text.trim(), ...extra })
+    setText('')
+  }
+
+  return (
+    <form className="vd-inline-add" onSubmit={submit}>
+      <input autoFocus className="vd-text-input" placeholder={placeholder}
+        value={text} onChange={e => setText(e.target.value)}
+        onKeyDown={e => e.key === 'Escape' && onCancel()} />
+      {extraFields && extraFields.map(f => (
+        <select key={f.key} className="vd-select" value={extra[f.key]}
+          onChange={e => setExtra(prev => ({ ...prev, [f.key]: e.target.value }))}>
+          {f.options.map(o => <option key={o} value={o}>{o}</option>)}
+        </select>
+      ))}
+      <button type="submit" className="vd-btn-add">Add</button>
+      <button type="button" className="vd-btn-cancel" onClick={onCancel}>×</button>
+    </form>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export default function VDiagram({ taskId, taskTitle, onClose }) {
+  const [data,       setData]       = useState(null)
+  const [loading,    setLoading]    = useState(true)
+  const [error,      setError]      = useState(null)
+  const [selectedReq, setSelectedReq] = useState(null)  // id of req in "link mode"
+  const [addingReq,  setAddingReq]  = useState(false)
+  const [addingVer,  setAddingVer]  = useState(false)
+
+  const containerRef = useRef(null)
+  const reqRefs      = useRef({})
+  const verRefs      = useRef({})
+
+  // ── Load ──────────────────────────────────────────────────────────────
+  const reload = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const d = await getVDiagram(taskId)
+      setData(d)
+      log('VDiagram loaded', taskId, d.summary)
+    } catch (e) {
+      warn('VDiagram load failed', e.message)
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [taskId])
+
+  useEffect(() => { reload() }, [reload])
+
+  // ── Close on Escape ───────────────────────────────────────────────────
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') {
+        if (selectedReq) { setSelectedReq(null); return }
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose, selectedReq])
+
+  // ── Mutations ─────────────────────────────────────────────────────────
+  const doAddReq = async ({ text, priority }) => {
+    await addRequirement(taskId, { text, priority })
+    setAddingReq(false)
+    reload()
+  }
+
+  const doAddVer = async ({ text, type }) => {
+    await addVerification(taskId, { text, type })
+    setAddingVer(false)
+    reload()
+  }
+
+  const doDeleteReq = async (id) => {
+    await deleteRequirement(id)
+    if (selectedReq === id) setSelectedReq(null)
+    reload()
+  }
+
+  const doDeleteVer = async (id) => {
+    await deleteVerification(id)
+    reload()
+  }
+
+  const doCycleStatus = async (ver) => {
+    await updateVerification(ver.id, { status: NEXT_STATUS[ver.status] })
+    reload()
+  }
+
+  const doToggleLink = async (reqId, verId) => {
+    const linked = data.links.some(
+      l => l.requirement_id === reqId && l.verification_id === verId
+    )
+    if (linked) {
+      await unlinkReqVer(reqId, verId)
+    } else {
+      await linkReqVer(reqId, verId)
+    }
+    reload()
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────
+  if (loading) return (
+    <div className="vd-backdrop" onClick={onClose}>
+      <div className="vd-modal" onClick={e => e.stopPropagation()}>
+        <div className="vd-loading">Loading V-diagram…</div>
+      </div>
+    </div>
+  )
+
+  if (error) return (
+    <div className="vd-backdrop" onClick={onClose}>
+      <div className="vd-modal" onClick={e => e.stopPropagation()}>
+        <div className="vd-error">Error: {error}</div>
+        <button className="vd-close" onClick={onClose}>×</button>
+      </div>
+    </div>
+  )
+
+  const { requirements, verifications, links, summary } = data
+  const linkedVerIds = selectedReq
+    ? new Set(links.filter(l => l.requirement_id === selectedReq).map(l => l.verification_id))
+    : null
+
+  // Requirements coverage: which reqs have at least one linked ver
+  const coveredReqIds = new Set(links.map(l => l.requirement_id))
+
+  return (
+    <div className="vd-backdrop" onClick={onClose}>
+      <div className="vd-modal" onClick={e => e.stopPropagation()}>
+
+        {/* ── Header ── */}
+        <div className="vd-header">
+          <div className="vd-header-left">
+            <span className="vd-title-label">V-Diagram</span>
+            <span className="vd-task-name">{taskTitle}</span>
+          </div>
+          <div className="vd-summary">
+            <span className="vd-stat">{summary.requirementCount} req</span>
+            <span className="vd-stat">{summary.verificationCount} ver</span>
+            <span className={`vd-stat ${summary.passed === summary.verificationCount && summary.verificationCount > 0 ? 'stat-all-pass' : ''}`}>
+              {summary.passed}/{summary.verificationCount} passed
+            </span>
+            {summary.failed > 0 && <span className="vd-stat stat-fail">{summary.failed} failed</span>}
+          </div>
+          <button className="vd-close" onClick={onClose} title="Close (Esc)">×</button>
+        </div>
+
+        {/* ── Link-mode banner ── */}
+        {selectedReq && (
+          <div className="vd-link-banner">
+            <span>Link mode — click verifications to toggle links for the selected requirement</span>
+            <button onClick={() => setSelectedReq(null)}>Done</button>
+          </div>
+        )}
+
+        {/* ── Column headers ── */}
+        <div className="vd-col-headers">
+          <div className="vd-col-head">Requirements</div>
+          <div className="vd-col-head-center">
+            <span className="vd-v-label">V</span>
+          </div>
+          <div className="vd-col-head">Verifications</div>
+        </div>
+
+        {/* ── Diagram body ── */}
+        <div className="vd-body" ref={containerRef}>
+
+          {/* Left: Requirements */}
+          <div className="vd-col vd-col-req">
+            {requirements.length === 0 && (
+              <div className="vd-empty">No requirements yet</div>
+            )}
+            {requirements.map(r => (
+              <div
+                key={r.id}
+                ref={el => { reqRefs.current[r.id] = el }}
+                className={`vd-item vd-req${selectedReq === r.id ? ' vd-item-selected' : ''}${!coveredReqIds.has(r.id) ? ' vd-req-uncovered' : ''}`}
+                onClick={() => setSelectedReq(prev => prev === r.id ? null : r.id)}
+                title={selectedReq === r.id ? 'Click to deselect' : 'Click to enter link mode'}
+              >
+                <div className="vd-item-top">
+                  <span className={`vd-priority-dot ${PRI_CLS[r.priority]}`} title={r.priority} />
+                  <span className="vd-item-text">{r.text}</span>
+                </div>
+                {r.source && <div className="vd-item-meta">Source: {r.source}</div>}
+                <button className="vd-item-delete" onClick={e => { e.stopPropagation(); doDeleteReq(r.id) }}>×</button>
+              </div>
+            ))}
+
+            {addingReq
+              ? <InlineAdd
+                  placeholder="Requirement text…"
+                  onAdd={doAddReq}
+                  onCancel={() => setAddingReq(false)}
+                  extraFields={[{ key: 'priority', default: 'medium', options: ['high', 'medium', 'low'] }]}
+                />
+              : <button className="vd-add-btn" onClick={() => setAddingReq(true)}>+ Add requirement</button>
+            }
+          </div>
+
+          {/* Center: SVG lines overlay */}
+          <div className="vd-center-col">
+            <Lines
+              links={links}
+              reqRefs={reqRefs}
+              verRefs={verRefs}
+              containerRef={containerRef}
+              selectedReqId={selectedReq}
+            />
+          </div>
+
+          {/* Right: Verifications */}
+          <div className="vd-col vd-col-ver">
+            {verifications.length === 0 && (
+              <div className="vd-empty">No verifications yet</div>
+            )}
+            {verifications.map(v => {
+              const si = VER_STATUS[v.status] || VER_STATUS.pending
+              const isLinked = linkedVerIds ? linkedVerIds.has(v.id) : false
+              return (
+                <div
+                  key={v.id}
+                  ref={el => { verRefs.current[v.id] = el }}
+                  className={`vd-item vd-ver vd-ver-${v.status}${isLinked ? ' vd-ver-linked' : ''}${selectedReq ? ' vd-ver-linkable' : ''}`}
+                  onClick={() => selectedReq && doToggleLink(selectedReq, v.id)}
+                >
+                  <div className="vd-item-top">
+                    <button
+                      className={`vd-status-btn ${si.cls}`}
+                      onClick={e => { e.stopPropagation(); doCycleStatus(v) }}
+                      title={`Status: ${si.label} — click to advance`}
+                    >
+                      {si.icon}
+                    </button>
+                    <span className="vd-item-text">{v.text}</span>
+                  </div>
+                  <div className="vd-item-meta">
+                    <span className="vd-ver-type">{v.type}</span>
+                    {v.verified_at && (
+                      <span className="vd-verified-at">{new Date(v.verified_at).toLocaleDateString()}</span>
+                    )}
+                  </div>
+                  {v.result_notes && <div className="vd-result-notes">{v.result_notes}</div>}
+                  <button className="vd-item-delete" onClick={e => { e.stopPropagation(); doDeleteVer(v.id) }}>×</button>
+                  {selectedReq && (
+                    <span className="vd-link-toggle" title={isLinked ? 'Unlink' : 'Link'}>
+                      {isLinked ? '⊟' : '⊕'}
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+
+            {addingVer
+              ? <InlineAdd
+                  placeholder="Verification step…"
+                  onAdd={doAddVer}
+                  onCancel={() => setAddingVer(false)}
+                  extraFields={[{ key: 'type', default: 'manual', options: VER_TYPES }]}
+                />
+              : <button className="vd-add-btn" onClick={() => setAddingVer(true)}>+ Add verification</button>
+            }
+          </div>
+        </div>
+
+        {/* ── Legend ── */}
+        <div className="vd-legend">
+          <span className="vd-leg-item"><span className="vd-priority-dot pri-high" /> High priority</span>
+          <span className="vd-leg-item"><span className="vd-priority-dot pri-medium" /> Medium</span>
+          <span className="vd-leg-item"><span className="vd-priority-dot pri-low" /> Low</span>
+          <span className="vd-leg-sep" />
+          {Object.entries(VER_STATUS).map(([k, v]) => (
+            <span key={k} className="vd-leg-item">
+              <span className={`vd-status-icon ${v.cls}`}>{v.icon}</span> {v.label}
+            </span>
+          ))}
+          <span className="vd-leg-sep" />
+          <span className="vd-leg-item vd-leg-hint">Click a requirement to enter link mode</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,53 @@
+// Thin fetch wrapper — CRA proxy forwards /api/* to Express on port 3001
+
+async function request(method, path, body) {
+  const opts = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  }
+  if (body !== undefined) opts.body = JSON.stringify(body)
+
+  const res = await fetch(path, opts)
+  if (res.status === 204) return null
+  const data = await res.json()
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
+  return data
+}
+
+// ── Boards ────────────────────────────────────────────────────────────────────
+
+export const getBoard = (id) => request('GET', `/api/boards/${id}`)
+
+// ── Tasks ─────────────────────────────────────────────────────────────────────
+
+export const createTask = (boardId, columnId, taskData) =>
+  request('POST', '/api/boards/tasks', { boardId, columnId, ...taskData })
+
+export const updateTask = (id, data) =>
+  request('PATCH', `/api/boards/tasks/${id}`, data)
+
+export const deleteTask = (id) =>
+  request('DELETE', `/api/boards/tasks/${id}`)
+
+export const moveTask = (id, targetColumnId, targetPosition) =>
+  request('POST', `/api/boards/tasks/${id}/move`, { targetColumnId, targetPosition })
+
+export const createSubBoard = (taskId) =>
+  request('POST', `/api/boards/tasks/${taskId}/sub-board`)
+
+// ── Automations ───────────────────────────────────────────────────────────────
+
+export const listAutomations = () => request('GET', '/api/automations')
+
+export const getAutomation = (id) => request('GET', `/api/automations/${id}`)
+
+export const createAutomation = (data) => request('POST', '/api/automations', data)
+
+export const updateAutomation = (id, data) => request('PATCH', `/api/automations/${id}`, data)
+
+export const deleteAutomation = (id) => request('DELETE', `/api/automations/${id}`)
+
+export const triggerAutomation = (id) => request('POST', `/api/automations/${id}/trigger`)
+
+export const getAutomationLogs = (id, limit = 20) =>
+  request('GET', `/api/automations/${id}/logs?limit=${limit}`)

--- a/src/api.js
+++ b/src/api.js
@@ -51,3 +51,32 @@ export const triggerAutomation = (id) => request('POST', `/api/automations/${id}
 
 export const getAutomationLogs = (id, limit = 20) =>
   request('GET', `/api/automations/${id}/logs?limit=${limit}`)
+
+// ── V-Diagram ─────────────────────────────────────────────────────────────────
+
+export const getVDiagram = (taskId) =>
+  request('GET', `/api/tasks/${taskId}/vdiagram`)
+
+export const addRequirement = (taskId, data) =>
+  request('POST', `/api/tasks/${taskId}/requirements`, data)
+
+export const updateRequirement = (id, data) =>
+  request('PATCH', `/api/requirements/${id}`, data)
+
+export const deleteRequirement = (id) =>
+  request('DELETE', `/api/requirements/${id}`)
+
+export const addVerification = (taskId, data) =>
+  request('POST', `/api/tasks/${taskId}/verifications`, data)
+
+export const updateVerification = (id, data) =>
+  request('PATCH', `/api/verifications/${id}`, data)
+
+export const deleteVerification = (id) =>
+  request('DELETE', `/api/verifications/${id}`)
+
+export const linkReqVer = (reqId, verId) =>
+  request('POST', `/api/requirements/${reqId}/link/${verId}`)
+
+export const unlinkReqVer = (reqId, verId) =>
+  request('DELETE', `/api/requirements/${reqId}/link/${verId}`)

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,103 @@
+const initialData = {
+  boards: {
+    root: {
+      id: 'root',
+      columns: {
+        col_automations: {
+          id: 'col_automations',
+          title: 'Automations',
+          tasks: ['task_1', 'task_7'],
+        },
+        col_todo: {
+          id: 'col_todo',
+          title: 'To Do',
+          tasks: ['task_2', 'task_8', 'task_9'],
+        },
+        col_late: {
+          id: 'col_late',
+          title: 'Late',
+          tasks: ['task_3'],
+        },
+        col_onHold: {
+          id: 'col_onHold',
+          title: 'Not My Problem',
+          subtitle: '(right now)',
+          tasks: ['task_6'],
+        },
+        col_inProgress: {
+          id: 'col_inProgress',
+          title: 'In Progress',
+          tasks: [],
+        },
+        col_completed: {
+          id: 'col_completed',
+          title: 'Completed',
+          tasks: ['task_4'],
+        },
+      },
+      columnOrder: [
+        'col_automations',
+        'col_todo',
+        'col_late',
+        'col_onHold',
+        'col_inProgress',
+        'col_completed',
+      ],
+      newTaskColumns: ['col_todo'],
+    },
+  },
+  tasks: {
+    task_1: { id: 'task_1', title: 'Trash', due: '22:00', repeat: 'Tuesday' },
+    task_2: {
+      id: 'task_2',
+      title: 'Design portfolio website',
+      description: 'Overall layout and structure',
+      due: '2022-02-01',
+    },
+    task_3: {
+      id: 'task_3',
+      title: 'Finish Bookshelf',
+      due: '2022-02-14',
+      boardId: 'task_3',
+    },
+    task_4: {
+      id: 'task_4',
+      title: 'Buy Stain',
+      description: 'Dark coffee color',
+      due: '2022-02-02',
+    },
+    task_5: {
+      id: 'task_5',
+      title: 'Apply Stain',
+      description: 'Assemble first — check for cold-warped boards',
+      due: '2022-02-02',
+    },
+    task_6: {
+      id: 'task_6',
+      title: 'Figure out Wipro W2',
+      description: 'Low confidence they will send one. Escalate on due date.',
+      due: '2022-03-01',
+    },
+    task_7: { id: 'task_7', title: 'Laundry', due: '12:00', repeat: 'Saturday' },
+    task_8: { id: 'task_8', title: 'Make this persistent', due: '2022-02-10' },
+    task_9: { id: 'task_9', title: 'Add sub-boards to tasks', due: '2022-02-10' },
+  },
+  // Pre-built sub-board for task_3 to demo the recursive feature
+  // (task_3 already has boardId: 'task_3' set above)
+  boardPath: ['root'],
+  nextId: 10,
+}
+
+// Lazily add the demo sub-board for task_3
+initialData.boards['task_3'] = {
+  id: 'task_3',
+  columns: {
+    col_todo: { id: 'col_todo', title: 'To Do', tasks: ['task_4', 'task_5'] },
+    col_inProgress: { id: 'col_inProgress', title: 'In Progress', tasks: [] },
+    col_completed: { id: 'col_completed', title: 'Done', tasks: [] },
+  },
+  columnOrder: ['col_todo', 'col_inProgress', 'col_completed'],
+  newTaskColumns: ['col_todo'],
+}
+
+export default initialData

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,228 @@
-import React,{useState} from 'react'
+import React, { useState, useCallback } from 'react'
 import ReactDOM from 'react-dom'
-import { DragDropContext } from 'react-beautiful-dnd'
-
 import './style.css'
-import initialData from './demo-data'
+import initialData from './data'
+import Board from './Board'
 
-import Lane,{changeLanes} from './lane'
+const STORAGE_KEY = 'taskboard_v2'
 
-
-let App=()=>{
-  
-
-  const [state,updateState] = useState(initialData)
-  let onDragEnd=(result)=>{
-      changeLanes(result,state,updateState)
+function loadState() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    return saved ? JSON.parse(saved) : initialData
+  } catch {
+    return initialData
   }
+}
+
+function saveState(state) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // storage unavailable — continue in-memory
+  }
+}
+
+function makeEmptyBoard(id) {
+  return {
+    id,
+    columns: {
+      col_todo: { id: 'col_todo', title: 'To Do', tasks: [] },
+      col_inProgress: { id: 'col_inProgress', title: 'In Progress', tasks: [] },
+      col_completed: { id: 'col_completed', title: 'Done', tasks: [] },
+    },
+    columnOrder: ['col_todo', 'col_inProgress', 'col_completed'],
+    newTaskColumns: ['col_todo'],
+  }
+}
+
+function App() {
+  const [state, setState] = useState(loadState)
+
+  const update = useCallback((updater) => {
+    setState((prev) => {
+      const next = updater(prev)
+      saveState(next)
+      return next
+    })
+  }, [])
+
+  const moveTask = useCallback(
+    (boardId, source, destination) => {
+      if (
+        source.droppableId === destination.droppableId &&
+        source.index === destination.index
+      ) return
+
+      update((prev) => {
+        const board = prev.boards[boardId]
+        const srcId = source.droppableId
+        const dstId = destination.droppableId
+        const srcTasks = [...board.columns[srcId].tasks]
+        const dstTasks = srcId === dstId ? srcTasks : [...(board.columns[dstId].tasks || [])]
+
+        const [moved] = srcTasks.splice(source.index, 1)
+        dstTasks.splice(destination.index, 0, moved)
+
+        return {
+          ...prev,
+          boards: {
+            ...prev.boards,
+            [boardId]: {
+              ...board,
+              columns: {
+                ...board.columns,
+                [srcId]: { ...board.columns[srcId], tasks: srcTasks },
+                [dstId]: { ...board.columns[dstId], tasks: dstTasks },
+              },
+            },
+          },
+        }
+      })
+    },
+    [update]
+  )
+
+  const addTask = useCallback(
+    (boardId, columnId, taskData) => {
+      update((prev) => {
+        const taskId = `task_${prev.nextId}`
+        return {
+          ...prev,
+          nextId: prev.nextId + 1,
+          tasks: {
+            ...prev.tasks,
+            [taskId]: { id: taskId, ...taskData },
+          },
+          boards: {
+            ...prev.boards,
+            [boardId]: {
+              ...prev.boards[boardId],
+              columns: {
+                ...prev.boards[boardId].columns,
+                [columnId]: {
+                  ...prev.boards[boardId].columns[columnId],
+                  tasks: [
+                    ...(prev.boards[boardId].columns[columnId].tasks || []),
+                    taskId,
+                  ],
+                },
+              },
+            },
+          },
+        }
+      })
+    },
+    [update]
+  )
+
+  const deleteTask = useCallback(
+    (boardId, columnId, taskId) => {
+      update((prev) => ({
+        ...prev,
+        boards: {
+          ...prev.boards,
+          [boardId]: {
+            ...prev.boards[boardId],
+            columns: {
+              ...prev.boards[boardId].columns,
+              [columnId]: {
+                ...prev.boards[boardId].columns[columnId],
+                tasks: prev.boards[boardId].columns[columnId].tasks.filter(
+                  (t) => t !== taskId
+                ),
+              },
+            },
+          },
+        },
+      }))
+    },
+    [update]
+  )
+
+  const drillIn = useCallback(
+    (taskId) => {
+      update((prev) => {
+        const boardExists = !!prev.boards[taskId]
+        return {
+          ...prev,
+          tasks: boardExists
+            ? prev.tasks
+            : {
+                ...prev.tasks,
+                [taskId]: { ...prev.tasks[taskId], boardId: taskId },
+              },
+          boards: boardExists
+            ? prev.boards
+            : { ...prev.boards, [taskId]: makeEmptyBoard(taskId) },
+          boardPath: [...prev.boardPath, taskId],
+        }
+      })
+    },
+    [update]
+  )
+
+  const navigateTo = useCallback(
+    (index) => {
+      update((prev) => ({
+        ...prev,
+        boardPath: prev.boardPath.slice(0, index + 1),
+      }))
+    },
+    [update]
+  )
+
+  const currentBoardId = state.boardPath[state.boardPath.length - 1]
+  const currentBoard = state.boards[currentBoardId]
+
+  const breadcrumb = state.boardPath.map((boardId, i) => ({
+    boardId,
+    title: boardId === 'root' ? 'Home' : state.tasks[boardId]?.title || boardId,
+    index: i,
+    isCurrent: i === state.boardPath.length - 1,
+  }))
+
   return (
-  <div className='laneGroup'>
-    <DragDropContext onDragEnd={onDragEnd}>
-        {state.columnOrder.map(col_i => {
-          const column = state.columns[col_i]
-          const tasks  = ((column.tasks)?column.tasks.map(task_i => state.tasks[task_i]):[])
-          const newTaskStart = state.newTaskStart.includes(column.id.substring(4))
-          return <Lane key={column.id} column={column} tasks={tasks} newTaskStart={newTaskStart}></Lane>
-        })}
-    </DragDropContext>
-  </div>)
+    <div className="app">
+      <header className="app-header">
+        <span className="app-logo">TaskBoard</span>
+        {state.boardPath.length > 1 && (
+          <nav className="breadcrumb">
+            {breadcrumb.map((crumb, i) => (
+              <span key={crumb.boardId} className="breadcrumb-item">
+                {i > 0 && <span className="breadcrumb-sep">›</span>}
+                {crumb.isCurrent ? (
+                  <span className="breadcrumb-current">{crumb.title}</span>
+                ) : (
+                  <button
+                    className="breadcrumb-link"
+                    onClick={() => navigateTo(crumb.index)}
+                  >
+                    {crumb.title}
+                  </button>
+                )}
+              </span>
+            ))}
+          </nav>
+        )}
+      </header>
+      <Board
+        key={currentBoardId}
+        boardId={currentBoardId}
+        board={currentBoard}
+        tasks={state.tasks}
+        onMoveTask={moveTask}
+        onAddTask={addTask}
+        onDeleteTask={deleteTask}
+        onDrillIn={drillIn}
+      />
+    </div>
+  )
 }
 
 ReactDOM.render(
   <React.StrictMode>
     <App />
-    
   </React.StrictMode>,
   document.getElementById('root')
-);
+)

--- a/src/index.js
+++ b/src/index.js
@@ -3,23 +3,34 @@ import ReactDOM from 'react-dom'
 import './style.css'
 import initialData from './data'
 import Board from './Board'
+import { log, warn, error } from './logger'
 
 const STORAGE_KEY = 'taskboard_v2'
 
 function loadState() {
   try {
     const saved = localStorage.getItem(STORAGE_KEY)
-    return saved ? JSON.parse(saved) : initialData
-  } catch {
-    return initialData
+    if (saved) {
+      const parsed = JSON.parse(saved)
+      log('State restored from localStorage', {
+        boards: Object.keys(parsed.boards),
+        tasks: Object.keys(parsed.tasks).length,
+        boardPath: parsed.boardPath,
+      })
+      return parsed
+    }
+  } catch (e) {
+    error('Failed to load state from localStorage, using initial data', e)
   }
+  log('Using initial data (no saved state found)')
+  return initialData
 }
 
 function saveState(state) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-  } catch {
-    // storage unavailable — continue in-memory
+  } catch (e) {
+    error('Failed to persist state to localStorage', e)
   }
 }
 
@@ -52,10 +63,23 @@ function App() {
       if (
         source.droppableId === destination.droppableId &&
         source.index === destination.index
-      ) return
+      ) {
+        log('moveTask: dropped in same position, no-op')
+        return
+      }
+
+      log('moveTask', {
+        board: boardId,
+        from: `${source.droppableId}[${source.index}]`,
+        to: `${destination.droppableId}[${destination.index}]`,
+      })
 
       update((prev) => {
         const board = prev.boards[boardId]
+        if (!board) {
+          warn('moveTask: board not found', boardId)
+          return prev
+        }
         const srcId = source.droppableId
         const dstId = destination.droppableId
         const srcTasks = [...board.columns[srcId].tasks]
@@ -87,6 +111,7 @@ function App() {
     (boardId, columnId, taskData) => {
       update((prev) => {
         const taskId = `task_${prev.nextId}`
+        log('addTask', { taskId, boardId, columnId, title: taskData.title })
         return {
           ...prev,
           nextId: prev.nextId + 1,
@@ -118,6 +143,7 @@ function App() {
 
   const deleteTask = useCallback(
     (boardId, columnId, taskId) => {
+      log('deleteTask', { taskId, boardId, columnId })
       update((prev) => ({
         ...prev,
         boards: {
@@ -144,6 +170,7 @@ function App() {
     (taskId) => {
       update((prev) => {
         const boardExists = !!prev.boards[taskId]
+        log('drillIn', { taskId, boardExists, newPath: [...prev.boardPath, taskId] })
         return {
           ...prev,
           tasks: boardExists
@@ -164,16 +191,21 @@ function App() {
 
   const navigateTo = useCallback(
     (index) => {
-      update((prev) => ({
-        ...prev,
-        boardPath: prev.boardPath.slice(0, index + 1),
-      }))
+      update((prev) => {
+        const newPath = prev.boardPath.slice(0, index + 1)
+        log('navigateTo', { index, newPath })
+        return { ...prev, boardPath: newPath }
+      })
     },
     [update]
   )
 
   const currentBoardId = state.boardPath[state.boardPath.length - 1]
   const currentBoard = state.boards[currentBoardId]
+
+  if (!currentBoard) {
+    error('currentBoard is undefined', { currentBoardId, boardPath: state.boardPath })
+  }
 
   const breadcrumb = state.boardPath.map((boardId, i) => ({
     boardId,
@@ -206,16 +238,18 @@ function App() {
           </nav>
         )}
       </header>
-      <Board
-        key={currentBoardId}
-        boardId={currentBoardId}
-        board={currentBoard}
-        tasks={state.tasks}
-        onMoveTask={moveTask}
-        onAddTask={addTask}
-        onDeleteTask={deleteTask}
-        onDrillIn={drillIn}
-      />
+      {currentBoard && (
+        <Board
+          key={currentBoardId}
+          boardId={currentBoardId}
+          board={currentBoard}
+          tasks={state.tasks}
+          onMoveTask={moveTask}
+          onAddTask={addTask}
+          onDeleteTask={deleteTask}
+          onDrillIn={drillIn}
+        />
+      )}
     </div>
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,255 +1,168 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import ReactDOM from 'react-dom'
 import './style.css'
-import initialData from './data'
 import Board from './Board'
-import { log, warn, error } from './logger'
+import { log, warn, error as logError } from './logger'
+import * as api from './api'
 
-const STORAGE_KEY = 'taskboard_v2'
+// BoardPath persists navigation across refreshes but NOT board data
+const PATH_KEY = 'taskboard_boardpath'
 
-function loadState() {
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    if (saved) {
-      const parsed = JSON.parse(saved)
-      log('State restored from localStorage', {
-        boards: Object.keys(parsed.boards),
-        tasks: Object.keys(parsed.tasks).length,
-        boardPath: parsed.boardPath,
-      })
-      return parsed
-    }
-  } catch (e) {
-    error('Failed to load state from localStorage, using initial data', e)
-  }
-  log('Using initial data (no saved state found)')
-  return initialData
+function loadPath() {
+  try { return JSON.parse(localStorage.getItem(PATH_KEY)) || ['root'] } catch { return ['root'] }
 }
-
-function saveState(state) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-  } catch (e) {
-    error('Failed to persist state to localStorage', e)
-  }
-}
-
-function makeEmptyBoard(id) {
-  return {
-    id,
-    columns: {
-      col_todo: { id: 'col_todo', title: 'To Do', tasks: [] },
-      col_inProgress: { id: 'col_inProgress', title: 'In Progress', tasks: [] },
-      col_completed: { id: 'col_completed', title: 'Done', tasks: [] },
-    },
-    columnOrder: ['col_todo', 'col_inProgress', 'col_completed'],
-    newTaskColumns: ['col_todo'],
-  }
+function savePath(p) {
+  try { localStorage.setItem(PATH_KEY, JSON.stringify(p)) } catch {}
 }
 
 function App() {
-  const [state, setState] = useState(loadState)
+  const [boardPath,    setBoardPath]    = useState(loadPath)
+  const [board,        setBoard]        = useState(null)
+  const [loading,      setLoading]      = useState(true)
+  const [fetchError,   setFetchError]   = useState(null)
+  const [liveStatuses, setLiveStatuses] = useState({})  // automationId → { status, result, lastRun }
+  const esRef = useRef(null)
 
-  const update = useCallback((updater) => {
-    setState((prev) => {
-      const next = updater(prev)
-      saveState(next)
-      return next
-    })
+  // ── Load current board ────────────────────────────────────────────────────
+  const currentBoardId = boardPath[boardPath.length - 1]
+
+  const fetchBoard = useCallback(async (boardId) => {
+    setLoading(true)
+    setFetchError(null)
+    try {
+      const data = await api.getBoard(boardId)
+      log('Loaded board', boardId, `(${data.columns.length} columns)`)
+      setBoard(data)
+    } catch (e) {
+      logError('Failed to load board', boardId, e.message)
+      setFetchError(e.message)
+    } finally {
+      setLoading(false)
+    }
   }, [])
 
-  const moveTask = useCallback(
-    (boardId, source, destination) => {
-      if (
-        source.droppableId === destination.droppableId &&
-        source.index === destination.index
-      ) {
-        log('moveTask: dropped in same position, no-op')
-        return
-      }
+  useEffect(() => {
+    fetchBoard(currentBoardId)
+  }, [currentBoardId, fetchBoard])
 
-      log('moveTask', {
-        board: boardId,
-        from: `${source.droppableId}[${source.index}]`,
-        to: `${destination.droppableId}[${destination.index}]`,
-      })
+  // ── SSE — live automation status ──────────────────────────────────────────
+  useEffect(() => {
+    const es = new EventSource('/api/automations/stream')
+    esRef.current = es
 
-      update((prev) => {
-        const board = prev.boards[boardId]
-        if (!board) {
-          warn('moveTask: board not found', boardId)
-          return prev
-        }
-        const srcId = source.droppableId
-        const dstId = destination.droppableId
-        const srcTasks = [...board.columns[srcId].tasks]
-        const dstTasks = srcId === dstId ? srcTasks : [...(board.columns[dstId].tasks || [])]
+    es.addEventListener('snapshot', (e) => {
+      const autos = JSON.parse(e.data)
+      const map = {}
+      autos.forEach(a => { map[a.id] = a })
+      setLiveStatuses(map)
+      log('SSE snapshot received', Object.keys(map).length, 'automations')
+    })
 
-        const [moved] = srcTasks.splice(source.index, 1)
-        dstTasks.splice(destination.index, 0, moved)
-
-        return {
-          ...prev,
-          boards: {
-            ...prev.boards,
-            [boardId]: {
-              ...board,
-              columns: {
-                ...board.columns,
-                [srcId]: { ...board.columns[srcId], tasks: srcTasks },
-                [dstId]: { ...board.columns[dstId], tasks: dstTasks },
-              },
-            },
-          },
-        }
-      })
-    },
-    [update]
-  )
-
-  const addTask = useCallback(
-    (boardId, columnId, taskData) => {
-      update((prev) => {
-        const taskId = `task_${prev.nextId}`
-        log('addTask', { taskId, boardId, columnId, title: taskData.title })
-        return {
-          ...prev,
-          nextId: prev.nextId + 1,
-          tasks: {
-            ...prev.tasks,
-            [taskId]: { id: taskId, ...taskData },
-          },
-          boards: {
-            ...prev.boards,
-            [boardId]: {
-              ...prev.boards[boardId],
-              columns: {
-                ...prev.boards[boardId].columns,
-                [columnId]: {
-                  ...prev.boards[boardId].columns[columnId],
-                  tasks: [
-                    ...(prev.boards[boardId].columns[columnId].tasks || []),
-                    taskId,
-                  ],
-                },
-              },
-            },
-          },
-        }
-      })
-    },
-    [update]
-  )
-
-  const deleteTask = useCallback(
-    (boardId, columnId, taskId) => {
-      log('deleteTask', { taskId, boardId, columnId })
-      update((prev) => ({
+    es.addEventListener('automation-update', (e) => {
+      const update = JSON.parse(e.data)
+      log('SSE automation-update', update.automationId, update.status)
+      setLiveStatuses(prev => ({
         ...prev,
-        boards: {
-          ...prev.boards,
-          [boardId]: {
-            ...prev.boards[boardId],
-            columns: {
-              ...prev.boards[boardId].columns,
-              [columnId]: {
-                ...prev.boards[boardId].columns[columnId],
-                tasks: prev.boards[boardId].columns[columnId].tasks.filter(
-                  (t) => t !== taskId
-                ),
-              },
-            },
-          },
-        },
+        [update.automationId]: { ...(prev[update.automationId] || {}), ...update },
       }))
-    },
-    [update]
-  )
+    })
 
-  const drillIn = useCallback(
-    (taskId) => {
-      update((prev) => {
-        const boardExists = !!prev.boards[taskId]
-        log('drillIn', { taskId, boardExists, newPath: [...prev.boardPath, taskId] })
-        return {
-          ...prev,
-          tasks: boardExists
-            ? prev.tasks
-            : {
-                ...prev.tasks,
-                [taskId]: { ...prev.tasks[taskId], boardId: taskId },
-              },
-          boards: boardExists
-            ? prev.boards
-            : { ...prev.boards, [taskId]: makeEmptyBoard(taskId) },
-          boardPath: [...prev.boardPath, taskId],
-        }
-      })
-    },
-    [update]
-  )
+    es.onerror = () => warn('SSE connection lost — will retry automatically')
 
-  const navigateTo = useCallback(
-    (index) => {
-      update((prev) => {
-        const newPath = prev.boardPath.slice(0, index + 1)
-        log('navigateTo', { index, newPath })
-        return { ...prev, boardPath: newPath }
-      })
-    },
-    [update]
-  )
+    return () => { es.close(); esRef.current = null }
+  }, [])
 
-  const currentBoardId = state.boardPath[state.boardPath.length - 1]
-  const currentBoard = state.boards[currentBoardId]
+  // ── Handlers ──────────────────────────────────────────────────────────────
+  const handleMoveTask = useCallback(async (taskId, targetColumnId, targetPosition) => {
+    log('moveTask', { taskId, targetColumnId, targetPosition })
+    // Optimistic update: refresh board after move
+    await api.moveTask(taskId, targetColumnId, targetPosition)
+    fetchBoard(currentBoardId)
+  }, [currentBoardId, fetchBoard])
 
-  if (!currentBoard) {
-    error('currentBoard is undefined', { currentBoardId, boardPath: state.boardPath })
-  }
+  const handleAddTask = useCallback(async (boardId, columnId, taskData) => {
+    log('addTask', { boardId, columnId, title: taskData.title })
+    await api.createTask(boardId, columnId, {
+      title: taskData.title,
+      dueDate: taskData.due || null,
+    })
+    fetchBoard(boardId)
+  }, [fetchBoard])
 
-  const breadcrumb = state.boardPath.map((boardId, i) => ({
-    boardId,
-    title: boardId === 'root' ? 'Home' : state.tasks[boardId]?.title || boardId,
-    index: i,
-    isCurrent: i === state.boardPath.length - 1,
+  const handleDeleteTask = useCallback(async (taskId) => {
+    log('deleteTask', taskId)
+    await api.deleteTask(taskId)
+    fetchBoard(currentBoardId)
+  }, [currentBoardId, fetchBoard])
+
+  const handleDrillIn = useCallback(async (taskId) => {
+    log('drillIn', taskId)
+    const { boardId } = await api.createSubBoard(taskId)
+    const newPath = [...boardPath, boardId]
+    setBoardPath(newPath)
+    savePath(newPath)
+    // Refresh parent so sub-board indicator updates
+    fetchBoard(boardId)
+  }, [boardPath, fetchBoard])
+
+  const navigateTo = useCallback((index) => {
+    const newPath = boardPath.slice(0, index + 1)
+    log('navigateTo', { index, newPath })
+    setBoardPath(newPath)
+    savePath(newPath)
+  }, [boardPath])
+
+  // ── Breadcrumb labels ─────────────────────────────────────────────────────
+  // When on a sub-board, the board.title is the task's title (set at creation time)
+  const breadcrumb = boardPath.map((bId, i) => ({
+    boardId: bId,
+    title:   bId === 'root' ? 'Home' : (i === boardPath.length - 1 && board ? board.title : bId),
+    index:   i,
+    isCurrent: i === boardPath.length - 1,
   }))
 
+  // ── Render ────────────────────────────────────────────────────────────────
   return (
     <div className="app">
       <header className="app-header">
         <span className="app-logo">TaskBoard</span>
-        {state.boardPath.length > 1 && (
+        {boardPath.length > 1 && (
           <nav className="breadcrumb">
             {breadcrumb.map((crumb, i) => (
               <span key={crumb.boardId} className="breadcrumb-item">
                 {i > 0 && <span className="breadcrumb-sep">›</span>}
-                {crumb.isCurrent ? (
-                  <span className="breadcrumb-current">{crumb.title}</span>
-                ) : (
-                  <button
-                    className="breadcrumb-link"
-                    onClick={() => navigateTo(crumb.index)}
-                  >
-                    {crumb.title}
-                  </button>
-                )}
+                {crumb.isCurrent
+                  ? <span className="breadcrumb-current">{crumb.title}</span>
+                  : <button className="breadcrumb-link" onClick={() => navigateTo(crumb.index)}>
+                      {crumb.title}
+                    </button>
+                }
               </span>
             ))}
           </nav>
         )}
       </header>
-      {currentBoard && (
-        <Board
-          key={currentBoardId}
-          boardId={currentBoardId}
-          board={currentBoard}
-          tasks={state.tasks}
-          onMoveTask={moveTask}
-          onAddTask={addTask}
-          onDeleteTask={deleteTask}
-          onDrillIn={drillIn}
-        />
-      )}
+
+      <main className="app-main">
+        {loading && <div className="loading-overlay">Loading…</div>}
+        {fetchError && (
+          <div className="error-banner">
+            Failed to load board: {fetchError}
+            <button onClick={() => fetchBoard(currentBoardId)}>Retry</button>
+          </div>
+        )}
+        {!loading && !fetchError && board && (
+          <Board
+            key={currentBoardId}
+            board={board}
+            liveStatuses={liveStatuses}
+            onMoveTask={handleMoveTask}
+            onAddTask={handleAddTask}
+            onDeleteTask={handleDeleteTask}
+            onDrillIn={handleDrillIn}
+          />
+        )}
+      </main>
     </div>
   )
 }

--- a/src/lane.jsx
+++ b/src/lane.jsx
@@ -1,75 +1,37 @@
-
-import Card from './card'
+import React from 'react'
 import { Droppable } from 'react-beautiful-dnd'
-import {dropfromArray} from './helper'
-export default function Lane(props) {
-    let column = props.column
-    let tasks = props.tasks
-    let newTaskStart = props.newTaskStart
-    let idx = 0
-    let NewTask
-    function hover(e) {
-        e.target.style.background = 'greenyellow'
-        }
-    function exitHover(e) {
-        e.target.style.background = ''
-    }
-    if (newTaskStart){
-        NewTask = <Card id={column.id+"_NewTask"} index={idx+1}/>
-    }
-    const header =  <div className='lane_title'>
-                        <h2>{column.title}</h2><span>{column.subtitle}</span>
-                    </div>
-    const lane_tasks = <div className="lane_tasks">
-                    <Droppable droppableId={column.id} index={props.index}>    
-                        {provided => (
-                            <div
-                            {...provided.droppableProps}
-                            ref={provided.innerRef}
-                            >
-                                {tasks.map((task,index)=>{
-                                    let card = {
-                                        id:task.id,
-                                        task:{task},
-                                        index:index
-                                    }
-                                    idx=index
-                                    return(<Card key={task.id} {...card}/>)
-                                })}
-                                
-                                <div className='dropZone'
-                                onMouseOver={hover}
-                                onMouseOut={exitHover}>
-                                {provided.placeholder}
-                                </div>
-                                {NewTask}
-                            </div>
-                        )}
-                    </Droppable>
-                </div>
-    return (
-        <div id={column.id} className="lane">
-            {header}
-            {lane_tasks}
-            
-        </div>
-    )
+import TaskCard from './TaskCard'
+import NewTaskForm from './NewTaskForm'
+
+export default function Lane({ column, tasks, hasNewTaskForm, onAddTask, onDeleteTask, onDrillIn }) {
+  return (
+    <div id={column.id} className="lane">
+      <div className="lane_title">
+        <h2>{column.title}</h2>
+        {column.subtitle && <span className="lane_subtitle">{column.subtitle}</span>}
+        <span className="task-count">{tasks.length}</span>
+      </div>
+      <Droppable droppableId={column.id}>
+        {(provided, snapshot) => (
+          <div
+            className={`lane_tasks${snapshot.isDraggingOver ? ' dragging-over' : ''}`}
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+          >
+            {tasks.map((task, index) => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                index={index}
+                onDelete={() => onDeleteTask(task.id)}
+                onDrillIn={() => onDrillIn(task.id)}
+              />
+            ))}
+            {provided.placeholder}
+            {hasNewTaskForm && <NewTaskForm onAdd={onAddTask} />}
+          </div>
+        )}
+      </Droppable>
+    </div>
+  )
 }
-export let changeLanes=(result,state,updateState)=>{
-    let lane_end = result.destination.droppableId.substring(4)  //col_# -> #
-    let lane_start = result.source.droppableId.substring(4)     //col_# -> #
-    let task_i = result.draggableId.substring(5) //task_# -> #
-    let data_columns = state.columns
-    let tasks = data_columns[lane_start].tasks
-    let newColumnData = {...data_columns}
-    if(!task_i.includes('NewTask')){
-        newColumnData[lane_start].tasks = dropfromArray(tasks, task_i)
-        newColumnData[lane_end].tasks.push(parseInt(task_i))
-        state.columns = {...newColumnData}
-    }else{
-        state.newTaskStart = dropfromArray(state.newTaskStart,lane_start)
-        state.newTaskStart.push(lane_end)
-    }
-    
-    updateState({...state})    
-  }

--- a/src/lane.jsx
+++ b/src/lane.jsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import { Droppable } from 'react-beautiful-dnd'
 import TaskCard from './TaskCard'
+import AutomationCard from './AutomationCard'
 import NewTaskForm from './NewTaskForm'
 
-export default function Lane({ column, tasks, hasNewTaskForm, onAddTask, onDeleteTask, onDrillIn }) {
+export default function Lane({
+  column, tasks, liveStatuses,
+  onAddTask, onDeleteTask, onDrillIn,
+}) {
   return (
     <div id={column.id} className="lane">
       <div className="lane_title">
@@ -18,17 +22,25 @@ export default function Lane({ column, tasks, hasNewTaskForm, onAddTask, onDelet
             ref={provided.innerRef}
             {...provided.droppableProps}
           >
-            {tasks.map((task, index) => (
-              <TaskCard
-                key={task.id}
-                task={task}
-                index={index}
-                onDelete={() => onDeleteTask(task.id)}
-                onDrillIn={() => onDrillIn(task.id)}
-              />
-            ))}
+            {tasks.map((task, index) =>
+              column.isAutomation
+                ? <AutomationCard
+                    key={task.id}
+                    task={task}
+                    index={index}
+                    liveStatuses={liveStatuses}
+                    onDelete={() => onDeleteTask(task.id)}
+                  />
+                : <TaskCard
+                    key={task.id}
+                    task={task}
+                    index={index}
+                    onDelete={() => onDeleteTask(task.id)}
+                    onDrillIn={() => onDrillIn(task.id)}
+                  />
+            )}
             {provided.placeholder}
-            {hasNewTaskForm && <NewTaskForm onAdd={onAddTask} />}
+            {column.allowNewTasks && <NewTaskForm onAdd={onAddTask} />}
           </div>
         )}
       </Droppable>

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,16 @@
+const isDev = process.env.NODE_ENV !== 'production'
+
+const prefix = '[TaskBoard]'
+
+export const log = (...args) => {
+  if (isDev) console.log(prefix, ...args)
+}
+
+export const warn = (...args) => {
+  if (isDev) console.warn(prefix, ...args)
+}
+
+// Errors always surface regardless of environment
+export const error = (...args) => {
+  console.error(prefix, ...args)
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,74 +1,429 @@
-body{
-    background-color: #282c34;
-}
-form li{
-    list-style-type: none;
-}
-h2{
-    margin-bottom: 0;
-}
-.Card{
-    height: auto;
-    max-width: 240px;
-    border: 3px;
-    border-color:grey;
-    color: grey;
-    border-style: solid;
-    border-radius: 6px;
-    margin-bottom: 6px;
-}
-.taskCard_title{
-    font-family:monospace;
-}
-.taskCard form{
-    text-transform: capitalize;
-}
-.lane{
-    height: 90vh;
-    max-width: 360px;
-    min-width: 234px;
-    border: 3px;
-    padding-inline: 6px;
-    border-color: black;
-    background-color: white;
-    border-style: solid;
-    border-radius: 7px;
-}
-.lane_title{
-    color: #4d4d4d;
-    font:icon;
-    padding-left: 10px;
-    height: 72px;
+* {
+  box-sizing: border-box;
 }
 
-.laneGroup .lane{
-    left: -120px;
-    float:left;
-    width:40px;
+body {
+  background-color: #1a1d23;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #e0e0e0;
 }
-.laneGroup .lane{
-    left: 120px;
-    float:left;
-    width:40px;
+
+/* ── App shell ──────────────────────────────────── */
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
 }
-.test{
-    height: 400px;
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 18px;
+  background: #21252b;
+  border-bottom: 1px solid #2e333b;
+  flex-shrink: 0;
 }
-.inputFormError{
-    color: red;
+
+.app-logo {
+  font-size: 16px;
+  font-weight: 700;
+  color: #61afef;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
 }
-#col_late{
-    background-color: tomato;
+
+/* ── Breadcrumb ─────────────────────────────────── */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  font-size: 13px;
 }
-#col_automations{
-    background-color: rgba(147, 66, 252, 0.3);
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
 }
-#col_completed{
-    background-color: #81ca94;
+
+.breadcrumb-sep {
+  color: #4b5263;
+  margin: 0 6px;
+  font-size: 15px;
 }
-#col_inProgress{
-    background-color: #408ce2;
+
+.breadcrumb-link {
+  background: none;
+  border: none;
+  color: #61afef;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: background 0.15s;
 }
-#col_onHold{
-    background-color: #ddcd73;
+
+.breadcrumb-link:hover {
+  background: rgba(97, 175, 239, 0.12);
+}
+
+.breadcrumb-current {
+  color: #e0e0e0;
+  font-weight: 600;
+  padding: 2px 6px;
+}
+
+/* ── Board ──────────────────────────────────────── */
+.laneGroup {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  padding: 16px;
+  overflow-x: auto;
+  flex: 1;
+  align-items: flex-start;
+}
+
+/* ── Lane ───────────────────────────────────────── */
+.lane {
+  flex-shrink: 0;
+  width: 280px;
+  border-radius: 8px;
+  background: #282c34;
+  border: 1px solid #2e333b;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 100px);
+}
+
+.lane_title {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 12px 12px 8px;
+  border-bottom: 1px solid #2e333b;
+  flex-shrink: 0;
+}
+
+.lane_title h2 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #abb2bf;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  flex: 1;
+}
+
+.lane_subtitle {
+  font-size: 11px;
+  color: #5c6370;
+}
+
+.task-count {
+  font-size: 11px;
+  color: #5c6370;
+  background: #2e333b;
+  border-radius: 10px;
+  padding: 1px 7px;
+  font-weight: 600;
+}
+
+.lane_tasks {
+  padding: 8px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 60px;
+  transition: background 0.15s;
+}
+
+.lane_tasks.dragging-over {
+  background: rgba(97, 175, 239, 0.04);
+}
+
+/* ── Lane colour overrides ──────────────────────── */
+#col_late {
+  border-color: rgba(224, 108, 117, 0.4);
+}
+#col_late .lane_title {
+  border-bottom-color: rgba(224, 108, 117, 0.25);
+  background: rgba(224, 108, 117, 0.08);
+}
+#col_late .lane_title h2 { color: #e06c75; }
+
+#col_automations {
+  border-color: rgba(147, 66, 252, 0.35);
+}
+#col_automations .lane_title {
+  border-bottom-color: rgba(147, 66, 252, 0.2);
+  background: rgba(147, 66, 252, 0.06);
+}
+#col_automations .lane_title h2 { color: #c678dd; }
+
+#col_completed {
+  border-color: rgba(152, 195, 121, 0.35);
+}
+#col_completed .lane_title {
+  border-bottom-color: rgba(152, 195, 121, 0.2);
+  background: rgba(152, 195, 121, 0.06);
+}
+#col_completed .lane_title h2 { color: #98c379; }
+
+#col_inProgress {
+  border-color: rgba(97, 175, 239, 0.35);
+}
+#col_inProgress .lane_title {
+  border-bottom-color: rgba(97, 175, 239, 0.2);
+  background: rgba(97, 175, 239, 0.06);
+}
+#col_inProgress .lane_title h2 { color: #61afef; }
+
+#col_onHold {
+  border-color: rgba(229, 192, 123, 0.3);
+}
+#col_onHold .lane_title {
+  border-bottom-color: rgba(229, 192, 123, 0.18);
+  background: rgba(229, 192, 123, 0.05);
+}
+#col_onHold .lane_title h2 { color: #e5c07b; }
+
+/* ── Card ───────────────────────────────────────── */
+.card {
+  background: #2e333b;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  padding: 10px;
+  cursor: grab;
+  border-left: 3px solid transparent;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.card.dragging {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+  cursor: grabbing;
+}
+
+.card.has-subboard {
+  border-left-color: #e5c07b;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 5px;
+}
+
+.card-meta {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.tag {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.due-tag {
+  background: rgba(224, 108, 117, 0.15);
+  color: #e06c75;
+}
+
+.repeat-tag {
+  background: rgba(152, 195, 121, 0.15);
+  color: #98c379;
+}
+
+.card-actions {
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+
+.card:hover .card-actions {
+  opacity: 1;
+}
+
+.btn-drill,
+.btn-delete {
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  line-height: 1;
+  padding: 0;
+  transition: background 0.1s, color 0.1s;
+}
+
+.btn-drill {
+  color: #5c6370;
+  font-size: 14px;
+}
+
+.btn-drill:hover,
+.btn-drill.active {
+  color: #e5c07b;
+  background: rgba(229, 192, 123, 0.12);
+}
+
+.btn-delete {
+  color: #5c6370;
+  font-size: 18px;
+}
+
+.btn-delete:hover {
+  background: rgba(224, 108, 117, 0.15);
+  color: #e06c75;
+}
+
+.card-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: #dcdfe4;
+  line-height: 1.45;
+}
+
+.card-description {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #5c6370;
+  line-height: 1.4;
+}
+
+.subboard-indicator {
+  margin-top: 6px;
+  font-size: 11px;
+  color: #e5c07b;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  opacity: 0.8;
+  transition: opacity 0.15s;
+}
+
+.subboard-indicator:hover {
+  opacity: 1;
+}
+
+/* ── New Task Form ──────────────────────────────── */
+.add-task-btn {
+  display: block;
+  width: 100%;
+  padding: 7px 10px;
+  background: none;
+  border: 1px dashed #2e333b;
+  border-radius: 6px;
+  color: #4b5263;
+  cursor: pointer;
+  font-size: 12px;
+  text-align: left;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  margin-top: 4px;
+}
+
+.add-task-btn:hover {
+  border-color: #61afef;
+  color: #61afef;
+  background: rgba(97, 175, 239, 0.04);
+}
+
+.new-task-form {
+  margin-top: 4px;
+  background: #21252b;
+  border-radius: 6px;
+  padding: 8px;
+  border: 1px solid #61afef;
+}
+
+.input-title {
+  width: 100%;
+  background: #1a1d23;
+  border: 1px solid #2e333b;
+  border-radius: 4px;
+  color: #e0e0e0;
+  padding: 6px 8px;
+  font-size: 13px;
+  margin-bottom: 6px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.input-title:focus {
+  border-color: #61afef;
+}
+
+.input-date {
+  flex: 1;
+  background: #1a1d23;
+  border: 1px solid #2e333b;
+  border-radius: 4px;
+  color: #e0e0e0;
+  padding: 5px 7px;
+  font-size: 12px;
+  outline: none;
+  min-width: 0;
+}
+
+.input-date:focus {
+  border-color: #61afef;
+}
+
+.form-row {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.btn-submit {
+  flex-shrink: 0;
+  padding: 5px 12px;
+  background: #61afef;
+  border: none;
+  border-radius: 4px;
+  color: #1a1d23;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-submit:hover {
+  background: #78bdf5;
+}
+
+.btn-cancel {
+  flex-shrink: 0;
+  padding: 5px 9px;
+  background: none;
+  border: 1px solid #2e333b;
+  border-radius: 4px;
+  color: #5c6370;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.btn-cancel:hover {
+  border-color: #4b5263;
+  color: #abb2bf;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -17,6 +17,46 @@ body {
   overflow: hidden;
 }
 
+.app-main {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #5c6370;
+  font-size: 14px;
+  background: #1a1d23;
+  z-index: 10;
+}
+
+.error-banner {
+  padding: 12px 18px;
+  background: rgba(224, 108, 117, 0.15);
+  border-bottom: 1px solid rgba(224, 108, 117, 0.3);
+  color: #e06c75;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.error-banner button {
+  padding: 3px 10px;
+  background: rgba(224,108,117,0.2);
+  border: 1px solid rgba(224,108,117,0.4);
+  border-radius: 4px;
+  color: #e06c75;
+  cursor: pointer;
+  font-size: 12px;
+}
+
 .app-header {
   display: flex;
   align-items: center;
@@ -426,4 +466,280 @@ body {
 .btn-cancel:hover {
   border-color: #4b5263;
   color: #abb2bf;
+}
+
+/* ── Automation card ─────────────────────────────── */
+.automation-card {
+  border-left-color: #5c6370;
+}
+.automation-card.border-success { border-left-color: #98c379; }
+.automation-card.border-failure { border-left-color: #e06c75; }
+.automation-card.border-error   { border-left-color: #e5c07b; }
+.automation-card.border-running { border-left-color: #61afef; }
+.automation-card.border-pending { border-left-color: #5c6370; }
+
+.auto-task-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.auto-status-dot {
+  font-size: 10px;
+  flex-shrink: 0;
+}
+.status-pending  { color: #5c6370; }
+.status-running  { color: #61afef; animation: spin 1s linear infinite; display: inline-block; }
+.status-success  { color: #98c379; }
+.status-failure  { color: #e06c75; }
+.status-error    { color: #e5c07b; }
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.auto-badges {
+  display: flex;
+  gap: 4px;
+  margin-top: 5px;
+  flex-wrap: wrap;
+}
+
+.type-tag {
+  background: rgba(97, 175, 239, 0.12);
+  color: #61afef;
+}
+
+.auto-none-hint {
+  margin-top: 5px;
+  font-size: 11px;
+  color: #4b5263;
+  font-style: italic;
+}
+
+.btn-auto-expand {
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  color: #5c6370;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.1s, color 0.1s;
+}
+.btn-auto-expand:hover { color: #61afef; background: rgba(97,175,239,0.12); }
+
+/* ── Automation detail panel ─────────────────────── */
+.auto-detail {
+  margin-top: 8px;
+  padding: 10px;
+  background: #1a1d23;
+  border-radius: 6px;
+  border: 1px solid #2e333b;
+  font-size: 12px;
+}
+
+.auto-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.auto-detail-title { font-weight: 600; color: #dcdfe4; }
+
+.auto-detail-close {
+  background: none;
+  border: none;
+  color: #5c6370;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0;
+}
+.auto-detail-close:hover { color: #e06c75; }
+
+.auto-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.auto-status-text { color: #7a8394; text-transform: capitalize; }
+
+.auto-detail-schedule,
+.auto-detail-lastrun {
+  color: #5c6370;
+  margin-bottom: 3px;
+  font-family: monospace;
+}
+
+.auto-result {
+  margin: 6px 0;
+  padding: 6px 8px;
+  background: #21252b;
+  border-radius: 4px;
+  font-size: 10px;
+  color: #abb2bf;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.auto-detail-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.btn-trigger {
+  padding: 4px 10px;
+  background: rgba(97,175,239,0.15);
+  border: 1px solid rgba(97,175,239,0.3);
+  border-radius: 4px;
+  color: #61afef;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-trigger:hover:not(:disabled) { background: rgba(97,175,239,0.25); }
+.btn-trigger:disabled { opacity: 0.5; cursor: default; }
+
+.btn-view-logs {
+  padding: 4px 10px;
+  background: none;
+  border: 1px solid #2e333b;
+  border-radius: 4px;
+  color: #7a8394;
+  font-size: 11px;
+  cursor: pointer;
+}
+.btn-view-logs:hover { border-color: #4b5263; color: #abb2bf; }
+
+.auto-logs { margin-top: 6px; max-height: 140px; overflow-y: auto; }
+.auto-log-empty { color: #4b5263; font-style: italic; text-align: center; padding: 8px; }
+
+.auto-log-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+  border-bottom: 1px solid #2e333b;
+  font-size: 11px;
+}
+.log-time   { color: #5c6370; font-family: monospace; }
+.log-status { text-transform: capitalize; font-weight: 600; }
+.log-status.success { color: #98c379; }
+.log-status.failure { color: #e06c75; }
+.log-status.error   { color: #e5c07b; }
+.log-dur    { color: #5c6370; font-family: monospace; }
+
+/* ── Automation form ─────────────────────────────── */
+.automation-form {
+  padding: 12px;
+  background: #21252b;
+  border-radius: 6px;
+  border: 1px solid #61afef;
+  margin-top: 6px;
+  font-size: 12px;
+}
+
+.auto-form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  font-weight: 600;
+  color: #dcdfe4;
+}
+
+.btn-cancel-icon {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #5c6370;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0;
+}
+.btn-cancel-icon:hover { color: #e06c75; }
+
+.automation-form label {
+  display: block;
+  margin-bottom: 8px;
+  color: #7a8394;
+}
+
+.automation-form label input,
+.automation-form label select {
+  display: block;
+  width: 100%;
+  margin-top: 3px;
+  background: #1a1d23;
+  border: 1px solid #2e333b;
+  border-radius: 4px;
+  color: #e0e0e0;
+  padding: 5px 7px;
+  font-size: 12px;
+  outline: none;
+}
+
+.automation-form label input:focus,
+.automation-form label select:focus {
+  border-color: #61afef;
+}
+
+.auto-config-fields { margin-top: 4px; }
+
+.auto-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: 10px;
+  color: #4b5263;
+}
+
+.webhook-url-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 4px;
+}
+.webhook-url {
+  flex: 1;
+  background: #1a1d23;
+  padding: 4px 7px;
+  border-radius: 4px;
+  font-size: 10px;
+  color: #98c379;
+  word-break: break-all;
+  border: 1px solid #2e333b;
+}
+.webhook-url-row button {
+  padding: 3px 8px;
+  background: rgba(152,195,121,0.1);
+  border: 1px solid rgba(152,195,121,0.3);
+  border-radius: 4px;
+  color: #98c379;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.auto-form-error {
+  padding: 6px 8px;
+  background: rgba(224,108,117,0.12);
+  border-radius: 4px;
+  color: #e06c75;
+  font-size: 11px;
+  margin-bottom: 8px;
+}
+
+.auto-form-btns {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -743,3 +743,469 @@ body {
   gap: 6px;
   margin-top: 10px;
 }
+
+/* ── V-diagram button on cards ──────────────────── */
+.btn-vd {
+  background: none;
+  border: 1px solid #3a3f4b;
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  color: #7a8394;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.btn-vd:hover {
+  background: rgba(229,192,123,0.12);
+  border-color: #e5c07b;
+  color: #e5c07b;
+}
+
+/* ── V-diagram backdrop & modal ─────────────────── */
+.vd-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.65);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.vd-modal {
+  background: #21252b;
+  border-radius: 10px;
+  border: 1px solid #3a3f4b;
+  width: 100%;
+  max-width: 960px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.7);
+}
+
+.vd-loading,
+.vd-error {
+  padding: 48px;
+  text-align: center;
+  color: #7a8394;
+  font-size: 14px;
+}
+.vd-error { color: #e06c75; }
+
+/* ── Header ─────────────────────────────────────── */
+.vd-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid #2e333b;
+  flex-shrink: 0;
+}
+
+.vd-header-left {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.vd-title-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: #e5c07b;
+  background: rgba(229,192,123,0.1);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.vd-task-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #dcdfe4;
+}
+
+.vd-summary {
+  display: flex;
+  gap: 8px;
+}
+
+.vd-stat {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: #2e333b;
+  color: #7a8394;
+  font-family: monospace;
+}
+.vd-stat.stat-all-pass { background: rgba(152,195,121,0.15); color: #98c379; }
+.vd-stat.stat-fail     { background: rgba(224,108,117,0.15); color: #e06c75; }
+
+.vd-close {
+  background: none;
+  border: none;
+  color: #5c6370;
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background 0.1s, color 0.1s;
+}
+.vd-close:hover { background: rgba(224,108,117,0.12); color: #e06c75; }
+
+/* ── Link-mode banner ───────────────────────────── */
+.vd-link-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 18px;
+  background: rgba(97,175,239,0.1);
+  border-bottom: 1px solid rgba(97,175,239,0.25);
+  font-size: 12px;
+  color: #61afef;
+  flex-shrink: 0;
+}
+.vd-link-banner button {
+  padding: 3px 10px;
+  background: rgba(97,175,239,0.15);
+  border: 1px solid rgba(97,175,239,0.35);
+  border-radius: 4px;
+  color: #61afef;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+/* ── Column headers ─────────────────────────────── */
+.vd-col-headers {
+  display: grid;
+  grid-template-columns: 1fr 80px 1fr;
+  padding: 8px 18px 0;
+  flex-shrink: 0;
+}
+
+.vd-col-head {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  color: #5c6370;
+}
+.vd-col-head:last-child { text-align: right; }
+
+.vd-col-head-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vd-v-label {
+  font-size: 20px;
+  font-weight: 900;
+  color: rgba(229,192,123,0.3);
+  letter-spacing: -2px;
+}
+
+/* ── Diagram body ───────────────────────────────── */
+.vd-body {
+  display: grid;
+  grid-template-columns: 1fr 80px 1fr;
+  gap: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 18px;
+  position: relative;
+  min-height: 200px;
+}
+
+.vd-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.vd-col-req { padding-right: 12px; }
+.vd-col-ver { padding-left: 12px; }
+
+.vd-center-col {
+  position: relative;
+  /* Lines rendered in the SVG use the container's full bounding rect */
+}
+
+/* ── SVG overlay ────────────────────────────────── */
+.vd-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+:root {
+  --link-color: rgba(97,175,239,0.55);
+  --link-color-hi: rgba(229,192,123,0.9);
+}
+
+.vd-link {
+  fill: none;
+  stroke: var(--link-color);
+  stroke-width: 1.5;
+}
+.vd-link-hi {
+  stroke: var(--link-color-hi);
+  stroke-width: 2.5;
+}
+
+/* ── Items ──────────────────────────────────────── */
+.vd-item {
+  position: relative;
+  background: #2e333b;
+  border-radius: 6px;
+  padding: 9px 30px 9px 10px;
+  border-left: 3px solid transparent;
+  transition: border-color 0.15s, background 0.15s;
+  cursor: default;
+}
+
+.vd-req { cursor: pointer; border-left-color: #3a3f4b; }
+.vd-req:hover { border-left-color: #e5c07b; background: #333840; }
+.vd-item-selected { border-left-color: #e5c07b !important; background: rgba(229,192,123,0.08) !important; }
+.vd-req-uncovered { opacity: 0.7; }
+.vd-req-uncovered::after {
+  content: '⚠';
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  font-size: 10px;
+  color: #e5c07b;
+  opacity: 0.6;
+}
+
+.vd-ver { border-left-color: #3a3f4b; }
+.vd-ver-linkable { cursor: pointer; }
+.vd-ver-linkable:hover { background: #333840; }
+.vd-ver-linked { border-left-color: #61afef; background: rgba(97,175,239,0.05); }
+
+.vd-ver-passed { border-left-color: #98c379; }
+.vd-ver-failed { border-left-color: #e06c75; }
+
+.vd-item-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.vd-item-text {
+  font-size: 12px;
+  color: #dcdfe4;
+  line-height: 1.4;
+  flex: 1;
+}
+
+.vd-item-meta {
+  margin-top: 4px;
+  font-size: 10px;
+  color: #5c6370;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.vd-ver-type {
+  background: #21252b;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: monospace;
+  color: #61afef;
+}
+
+.vd-verified-at { color: #5c6370; }
+
+.vd-result-notes {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #7a8394;
+  font-style: italic;
+}
+
+.vd-item-delete {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: none;
+  border: none;
+  color: transparent;
+  cursor: pointer;
+  font-size: 15px;
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.1s, background 0.1s;
+}
+.vd-item:hover .vd-item-delete { color: #5c6370; }
+.vd-item-delete:hover { color: #e06c75 !important; background: rgba(224,108,117,0.12); }
+
+.vd-link-toggle {
+  position: absolute;
+  bottom: 6px;
+  right: 8px;
+  font-size: 14px;
+  color: #61afef;
+}
+
+/* ── Priority dots ──────────────────────────────── */
+.vd-priority-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+.pri-high   { background: #e06c75; }
+.pri-medium { background: #e5c07b; }
+.pri-low    { background: #5c6370; }
+
+/* ── Verification status ────────────────────────── */
+.vd-status-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 1px;
+  transition: transform 0.1s;
+}
+.vd-status-btn:hover { transform: scale(1.25); }
+
+.vd-status-icon { font-size: 12px; }
+
+.vs-pending     { color: #4b5263; }
+.vs-in-progress { color: #61afef; }
+.vs-passed      { color: #98c379; }
+.vs-failed      { color: #e06c75; }
+
+/* ── Inline add form ────────────────────────────── */
+.vd-inline-add {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  background: #2e333b;
+  border-radius: 6px;
+  padding: 7px 8px;
+  border: 1px solid #61afef;
+}
+
+.vd-text-input {
+  flex: 1;
+  background: #1a1d23;
+  border: 1px solid #3a3f4b;
+  border-radius: 4px;
+  color: #e0e0e0;
+  padding: 4px 7px;
+  font-size: 12px;
+  outline: none;
+  min-width: 0;
+}
+.vd-text-input:focus { border-color: #61afef; }
+
+.vd-select {
+  background: #1a1d23;
+  border: 1px solid #3a3f4b;
+  border-radius: 4px;
+  color: #abb2bf;
+  padding: 4px 5px;
+  font-size: 11px;
+  outline: none;
+  flex-shrink: 0;
+}
+
+.vd-btn-add {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  background: #61afef;
+  border: none;
+  border-radius: 4px;
+  color: #1a1d23;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.vd-btn-cancel {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: #5c6370;
+  font-size: 16px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.vd-add-btn {
+  background: none;
+  border: 1px dashed #2e333b;
+  border-radius: 6px;
+  color: #4b5263;
+  padding: 7px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, color 0.15s;
+}
+.vd-add-btn:hover { border-color: #61afef; color: #61afef; }
+
+/* ── Empty state ────────────────────────────────── */
+.vd-empty {
+  font-size: 12px;
+  color: #4b5263;
+  font-style: italic;
+  padding: 12px 0;
+}
+
+/* ── Legend ─────────────────────────────────────── */
+.vd-legend {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 18px;
+  border-top: 1px solid #2e333b;
+  font-size: 10px;
+  color: #5c6370;
+  flex-shrink: 0;
+}
+
+.vd-leg-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.vd-leg-sep {
+  width: 1px;
+  height: 12px;
+  background: #2e333b;
+}
+
+.vd-leg-hint { color: #4b5263; font-style: italic; }


### PR DESCRIPTION
- New data model: flat tasks store + boards map, each board owns its columns
- localStorage persistence (taskboard_v2 key, survives page refresh)
- Working new-task form: creates tasks that actually land in state
- Task deletion via × button (visible on hover)
- Drill-in button on every card creates a full sub-board for that task;
  clicking again navigates into it — boards nest arbitrarily deep
- Breadcrumb navigation to move back up the board hierarchy
- Board.jsx: reusable board component with its own DragDropContext
- Lane.jsx: clean Droppable column, task-count badge, colour-coded headers
- TaskCard.jsx: Draggable card, shows sub-board indicator when board exists
- NewTaskForm.jsx: controlled expand/collapse form with date picker
- style.css: full dark-theme rewrite using flexbox layout (removes broken float rules)
- Demo data: task_3 "Finish Bookshelf" ships with a pre-built sub-board

https://claude.ai/code/session_01MipwYXFpLJi48d7nqG47sX